### PR TITLE
fixing printf failing under non-C locales

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -723,7 +723,7 @@ create_lxc_container() {
                 local used_pct=$(echo "$line" | awk '{print $7}')
                 
                 storage_names+=("$storage_name")
-                printf "  %d) %-15s %-8s %6.1f GB free of %6.1f GB (%s used)\n" \
+                LC_ALL=C printf "  %d) %-15s %-8s %6.1f GB free of %6.1f GB (%s used)\n" \
                     "$idx" "$storage_name" "$storage_type" "$avail_gb" "$total_gb" "$used_pct"
                 
                 if [[ "$storage_name" == "$DEFAULT_STORAGE" ]]; then


### PR DESCRIPTION
Ensuring numeric values are parsed using a consistent locale. Fixes an issue where printf failed under non-C locales (e.g. fr_FR) due to the use of . as a decimal separator.