### PR TITLE
Fix X-RateLimit-Limit header value

### DIFF
--- a/internal/api/rate_limit_config.go
+++ b/internal/api/rate_limit_config.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -156,7 +157,7 @@ func UniversalRateLimitMiddleware(next http.Handler) http.Handler {
 		if !limiter.Allow(ip) {
 			// Add retry-after header
 			w.Header().Set("Retry-After", "60")
-			w.Header().Set("X-RateLimit-Limit", string(rune(limiter.limit)))
+			w.Header().Set("X-RateLimit-Limit", strconv.Itoa(limiter.limit))
 			w.Header().Set("X-RateLimit-Remaining", "0")
 			w.Header().Set("X-RateLimit-Reset", time.Now().Add(limiter.window).Format(time.RFC3339))
 


### PR DESCRIPTION
I've been having intermittent issues with websockets using Pulse through Caddy. After drilling down into debug logs in Caddy, I've noticed the following error:  
`net/http: HTTP/1.x transport connection broken: malformed MIME header line: X-Ratelimit-Limit: \u0005`

Note the `\u0005` there. Looking into the code, I believe the way limit values are set in the header are incorrect at the moment. I'm not proficient in go, but after looking up `rune`, it would appear [the relevant code](https://github.com/rcourtman/Pulse/blame/170dc80da3a2e95260ec30503e6679f8fb16e1cd/internal/api/rate_limit_config.go#L159) means "treat this 5 as unicode code point" -> \u0005. My understanding is the limit value should be set as its string representation in the header.

Hence the proposed change. Again, not proficient in go, but [tested in an online go sandbox](https://go.dev/play/p/PPX1_aZuzkQ).