### PR TITLE
Fix refresh_smart_cache function to work in Debian 13 (trixie)

### DIFF
--- a/scripts/install-sensor-proxy.sh
+++ b/scripts/install-sensor-proxy.sh
@@ -835,9 +835,6 @@ get_cached_smart() {
 
 # Function to refresh SMART cache in background
 refresh_smart_cache() {
-    # Mark this process for detection
-    exec -a pulse-sensor-wrapper-refresh bash
-
     local cache_file="$CACHE_DIR/smart-temps.json"
     local temp_file="${cache_file}.tmp.$$"
     local disks=()
@@ -856,7 +853,7 @@ refresh_smart_cache() {
         # timeout: prevent hanging on problematic drives
 
         local output
-        if output=$(timeout ${MAX_SMARTCTL_TIME}s smartctl -n standby,after -A --json=o "$dev" 2>/dev/null); then
+        if output=$(timeout ${MAX_SMARTCTL_TIME}s smartctl -n standby -A --json=o "$dev" 2>/dev/null); then
             # Parse the JSON output
             local temp=$(echo "$output" | jq -r '
                 .temperature.current //


### PR DESCRIPTION
Removed process detection for refresh_smart_cache function (because was causing problems) and adjusted `smartctl` command parameters `after` doesn't exists in smartctl 7.4 and will cause an error

```console
# timeout 5s smartctl -n standby,after -A --json=o /dev/nvme0n1
smartctl 7.4 2024-10-15 r5620 [x86_64-linux-6.14.11-1-pve] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

=======> INVALID ARGUMENT TO -n: standby,after
=======> VALID ARGUMENTS ARE: never, sleep[,STATUS[,STATUS2]], standby[,STATUS[,STATUS2]], idle[,STATUS[,STATUS2]] <=======

Use smartctl -h to get a usage summary
```