### PR TITLE
Update install-docker-agent.sh to handle log_error and calculated checksum new line

### DIFF
--- a/scripts/install-docker-agent.sh
+++ b/scripts/install-docker-agent.sh
@@ -38,6 +38,10 @@ log_warn() {
     printf '[WARN] %s\n' "$1" >&2
 }
 
+log_error() {
+    printf '[ERROR] %s\n' "$1" >&2
+}
+
 log_header() {
     printf '\n== %s ==\n' "$1"
 }
@@ -1715,7 +1719,7 @@ verify_agent_checksum() {
         return 0
     fi
 
-    if [[ "$FETCHED_CHECKSUM" != "$CALCULATED_CHECKSUM" ]]; then
+    if [[ "$(echo "$FETCHED_CHECKSUM" | tr -d '\r\n')" != "$(echo "$CALCULATED_CHECKSUM" | tr -d '\r\n')" ]]; then
         rm -f "$AGENT_PATH"
         log_error "Checksum mismatch. Expected $FETCHED_CHECKSUM but downloaded $CALCULATED_CHECKSUM"
         return 1


### PR DESCRIPTION
- What changed
Added missing function log_error
Updated checksum check to handle \r at the end of calculated_checksum

- Why it changed
Got error that log_error did not exist, probably caused by the checksum check
Checksum check failed because of the \r in calculated_checksum

- Testing performed
Verified by running the script with the changes. No changes affecting other parts.

- Rollout / migration concerns
None
