### PR TITLE
fix: Replace external favicon with inline base64 data URI

### DIFF
--- a/frontend-modern/index.html
+++ b/frontend-modern/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAABlElEQVR4nJVTPU8CQRC93+LtYRThB6i9Wqu97NJgCbR+Sy/oL1Cg9aszAqXS6B/QHnbvQsJBIKFY8/ZuN2duY+Ikk9uZzLx983bOcSy2fDDIeVRUCRMNuMdEBTlbbbqR8a7HhLQ5obzjFoOsY7NMge8QKkIUblYDedGeyFZvphxn5CIQEbpsuJ26mcTNp81Qfnwt5MldKPdqI+XIfX4v1FeBMD4mBX/VABDKO7r58W0ucyU/RT9f8uXT+1wBqxzlvYg6G+Q1bdxsa06CgMlGJRpH6eFRUUWAOQ16XFx/mCrHWefB8qwV1WUoL4P+DYJ2byZ3L0emEI3aru6nJr9fG8lmdxZrIRoAuEYAtSHYvwCoqDtYEgTn7YlRWY+ARnhSF9DXdWqEJRqsJUXM/yXiYSTiejneCf2UhPFXJCAinsoGgtxzfy6PbjVL3jV74BaDrF4kgOilgSaYGbSRO45fCYvkMX/l1zZiPTUI3hmaQCw4AAxtxsducbhl/R8wkx7H6pS/pG62GUaCwup3pqKuzsndT9gPdyIXN38jKjgAAAAASUVORK5CYII=" />
     <title>Pulse</title>
   </head>
   <body>
@@ -13,4 +13,4 @@
 
     <script src="/src/index.tsx" type="module"></script>
   </body>
-</html>
+</html>%


### PR DESCRIPTION
Replace external SVG favicon reference with an inline base64-encoded PNG to ensure immediate favicon availability without additional HTTP requests.

Changes:
- Remove dependency on external /logo.svg file
- Embed 16x16 PNG favicon directly in HTML as data URI
- Improves initial page load performance by eliminating favicon fetch
- Ensures favicon displays correctly even if asset loading fails
- Maintains cross-browser compatibility with PNG format

The base64-encoded favicon is now self-contained within the HTML, reducing external dependencies and potential 404 errors.