### PR TITLE
Fix #1193: Change memory balloon segment color from yellow to blue

### DIFF
--- a/frontend-modern/src/components/Dashboard/StackedMemoryBar.tsx
+++ b/frontend-modern/src/components/Dashboard/StackedMemoryBar.tsx
@@ -27,7 +27,7 @@ const anomalySeverityClass: Record<string, string> = {
 // Colors for memory segments
 const MEMORY_COLORS = {
     active: 'rgba(34, 197, 94, 0.6)',   // green (base, overridden by threshold)
-    balloon: 'rgba(234, 179, 8, 0.6)',  // yellow
+    balloon: 'rgba(59, 130, 246, 0.6)',  // yellow to blue
     swap: 'rgba(168, 85, 247, 0.6)',    // purple
 };
 
@@ -253,7 +253,7 @@ export function StackedMemoryBar(props: StackedMemoryBarProps) {
 
                                     <Show when={(props.balloon || 0) > 0 && (props.balloon || 0) < props.total}>
                                         <div class="flex justify-between gap-3 py-0.5 border-t border-gray-700/50">
-                                            <span class="text-yellow-400">Balloon Limit</span>
+                                            <span class="text-blue-400">Balloon Limit</span>
                                             <span class="whitespace-nowrap text-gray-300">
                                                 {formatBytes(props.balloon || 0)}
                                             </span>


### PR DESCRIPTION
## What changed
Updated the memory balloon segment color in the StackedMemoryBar component from yellow to blue.

## Why
The previous yellow color closely resembled warning/alert states in the UI, which caused confusion when memory ballooning was active.  
Blue better represents an informational cap/limit rather than a warning condition.

## Files modified
- frontend-modern/src/components/Dashboard/StackedMemoryBar.tsx

## Testing performed
- Verified in dev mode using `npm run dev`
- Verified production build using `npm run build`
- Confirmed:
  - Used memory remains green
  - Balloon limit now appears blue
  - Tooltip label color is consistent
  - No layout or rendering issues observed

## Type of change
- UI / Cosmetic improvement

After SS:
<img width="887" height="496" alt="After-Pulse" src="https://github.com/user-attachments/assets/f3e1870e-7f12-4ab6-8961-cab68e1f1725" />
