### PR TITLE
docs: add LXC console access instructions

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -27,6 +27,29 @@ Go to **Settings → Proxmox**.
 
 If you want Pulse to find servers automatically, enable discovery in **Settings → System → Network** and then return to **Settings → Proxmox** to review discovered servers.
 
+### How do I access the LXC console to run commands?
+If you installed Pulse using the LXC installer, the container is created *without a root password*.  The LXC container uses Proxmox host-level authentication via **pct enter** rather than traditional password login. This is the recommended approach for Proxmox-managed containers.
+
+To access the console and run commands (like `update` or `journalctl -u pulse` or `pulse bootstrap-token`), use the Proxmox host shell:
+
+**From Proxmox Host Shell** (SSH into your Proxmox host first):
+```bash
+pct enter <VMID>  # e.g., pct enter 100
+```
+
+This gives you direct root access without requiring a password.
+
+**Find your container ID**:
+```bash
+pct list | grep -i pulse
+```
+
+**Note**: The Proxmox web console will show a `login:` prompt, but you cannot log in without first setting a password. To set a password for web console or SSH access:
+```bash
+pct enter <VMID>
+passwd  # Set root password
+```
+
 ### How do I change the port?
 - **Systemd**: `sudo systemctl edit pulse`, add `Environment="FRONTEND_PORT=8080"`, restart.
 - **Docker**: Use `-p 8080:7655` in your run command.


### PR DESCRIPTION
## Summary
Adds instructions for accessing LXC console in FAQ

## Changes
- Added "How do I access the LXC console to run commands?" entry to FAQ.md

 ## Why
Users frequently need to run commands like `journalctl -u pulse` but documentation never explained how to access the LXC console. The installer creates containers without a root password, requiring `pct enter <VMID>` from Proxmox host. As a new user of Pulse, this stumped me for a bit - thought it best to give feedback to answer the same question I had