### PR TITLE
Add Docker rootless and macOS Desktop socket detection

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -180,6 +180,24 @@ You can also toggle "Hide Docker Update Buttons" from the UI: **Settings → Age
 
 ---
 
+## 🐧 Docker Rootless
+
+Pulse auto-detects Docker rootless sockets when `--enable-docker` is used:
+
+- **Linux rootless**: `/run/user/{uid}/docker.sock` (or `$XDG_RUNTIME_DIR/docker.sock`)
+- **macOS Docker Desktop**: `~/.docker/run/docker.sock`
+
+No extra configuration is needed — the agent probes these paths automatically before falling back to the default `/var/run/docker.sock`.
+
+To override socket detection, set the `DOCKER_HOST` environment variable:
+
+```bash
+export DOCKER_HOST=unix:///run/user/1000/docker.sock
+pulse-agent --enable-docker
+```
+
+---
+
 ## 🛠️ Troubleshooting
 
 - **Forgot Password?**


### PR DESCRIPTION
## Summary

- Adds Docker rootless socket probing (`$XDG_RUNTIME_DIR/docker.sock` / `/run/user/{uid}/docker.sock`) to `buildRuntimeCandidates()`, mirroring existing Podman rootless detection
- Adds macOS Docker Desktop socket probing (`~/.docker/run/docker.sock`)
- New sockets are tried before the default `/var/run/docker.sock` for `RuntimeDocker` and `RuntimeAuto`; `RuntimePodman` is unaffected

Fixes #1200

## Test plan

- [x] Existing `TestBuildRuntimeCandidates` updated with new minimum counts
- [x] `TestBuildRuntimeCandidatesContent` extended to verify docker rootless inclusion/exclusion
- [x] New `TestBuildRuntimeCandidatesDockerRootless` — validates XDG-based path generation
- [x] New `TestBuildRuntimeCandidatesDockerDesktop` — validates desktop socket for Docker/Auto, excluded for Podman
- [ ] Manual: restart agent without `DOCKER_HOST` on a rootless Docker host and verify auto-detection