### PR TITLE
feat(docker): add macOS Docker Desktop socket auto-detection

### DIFF
--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -180,6 +180,18 @@ You can also toggle "Hide Docker Update Buttons" from the UI: **Settings → Age
 
 ---
 
+## 🍎 macOS Docker Desktop Socket
+
+On macOS, Docker Desktop exposes a socket at `~/.docker/run/docker.sock`. Pulse auto-detects this path when `--enable-docker` is used with `RuntimeDocker` or `RuntimeAuto`, so no extra configuration is needed.
+
+To override, set `DOCKER_HOST`:
+
+```bash
+export DOCKER_HOST=unix://$HOME/.docker/run/docker.sock
+```
+
+---
+
 ## 🛠️ Troubleshooting
 
 - **Forgot Password?**

--- a/internal/dockeragent/agent.go
+++ b/internal/dockeragent/agent.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -507,6 +508,14 @@ func buildRuntimeCandidates(preference RuntimeKind) []runtimeCandidate {
 			host:  rootlessDocker,
 			label: "docker rootless socket",
 		})
+
+		// macOS Docker Desktop socket
+		if home := os.Getenv("HOME"); home != "" {
+			add(runtimeCandidate{
+				host:  "unix://" + filepath.Join(home, ".docker", "run", "docker.sock"),
+				label: "docker desktop socket",
+			})
+		}
 
 		add(runtimeCandidate{
 			host:           "unix:///var/run/docker.sock",


### PR DESCRIPTION
## Summary

- Probes `~/.docker/run/docker.sock` for `RuntimeDocker` and `RuntimeAuto` before falling back to `/var/run/docker.sock`
- Lets the agent connect on macOS Docker Desktop without requiring `DOCKER_HOST` to be set manually
- Scoped to **only** the macOS Desktop socket — the Linux rootless fix shipped in v5.1.10

Follow-up from #1265 per @rcourtman's request.

Ref #1200

## Test plan

- [x] `TestBuildRuntimeCandidatesDockerDesktop` — validates Docker/Auto include, Podman excludes, ordering before default socket
- [x] Existing `TestBuildRuntimeCandidates` minimum counts updated
- [ ] Manual: restart agent on macOS Docker Desktop without `DOCKER_HOST` and verify auto-detection