### PR TITLE
fix(ai): deduplicate node and host entries in mention picker

### DIFF
--- a/frontend-modern/src/components/AI/Chat/mentionResources.ts
+++ b/frontend-modern/src/components/AI/Chat/mentionResources.ts
@@ -204,6 +204,8 @@ export function buildMentionResources(state: MentionStateSubset): MentionResourc
       [
         `node-id:${node.instance}:${node.name}`,
         nodeAlias(node.instance, node.clusterName, node.name),
+        ...(node.linkedHostAgentId ? [`host-link:${node.linkedHostAgentId}`] : []),
+        `node-backend-id:${node.id}`,
       ],
     );
   }
@@ -223,6 +225,8 @@ export function buildMentionResources(state: MentionStateSubset): MentionResourc
         `agent-host-id:${host.id}`,
         `host-name:${hostName}`,
         `host-hostname:${host.hostname}`,
+        `host-link:${host.id}`,
+        ...(host.linkedNodeId ? [`node-backend-id:${host.linkedNodeId}`] : []),
       ],
     );
   }


### PR DESCRIPTION
## Summary

- Fixes duplicate entries in the AI assistant `@`-mention picker when a pulse-agent is installed on a PVE node (#1252)
- Adds cross-type aliases (`host-link:` and `node-backend-id:`) to `buildMentionResources()` so linked nodes and hosts merge into a single mention resource via `linkedHostAgentId` / `linkedNodeId`
- Adds 3 test cases covering dedup via `linkedHostAgentId`, dedup via `linkedNodeId`, and no false merges for unrelated entries

## Test plan

- [x] Existing mention resource tests pass (2/2)
- [x] New dedup tests pass (3/3)
- [x] Full frontend test suite passes (402/402)
- [ ] Manual: open AI chat on a PVE instance with host agents, verify `@`-mention picker shows one entry per machine