### PR TITLE
Change last refresh time display format to system locale

### DIFF
--- a/frontend-modern/src/App.tsx
+++ b/frontend-modern/src/App.tsx
@@ -368,11 +368,10 @@ function App() {
   const formatLastUpdate = (timestamp: string) => {
     if (!timestamp) return '';
     const date = new Date(timestamp);
-    return date.toLocaleTimeString('en-US', {
+    return date.toLocaleTimeString(undefined, {
       hour: 'numeric',
       minute: '2-digit',
-      second: '2-digit',
-      hour12: true
+      second: '2-digit'
     });
   };
 


### PR DESCRIPTION
**Summary:** Updates the **"last refresh"** time display to respect the user locale, replacing the hardcoded `en-US` 12h format while maintaining full detail (hours, minutes, seconds). This allows the system settings to determine the 12h/24h cycle and regional separators.

**Rationale:** Over 85% of the world uses 24h time; a hardcoded 12h format is unintuitive for most global users. This also aligns with modern apps that defer to system locale by default for better accessibility.

**Tests:** Ran `npm run test`. All passing.