### PR TITLE
Fix notifications ignoring quiet hours during escalation

### DIFF
--- a/internal/alerts/alerts.go
+++ b/internal/alerts/alerts.go
@@ -2262,6 +2262,28 @@ func (m *Manager) ShouldSuppressResolvedNotification(alert *Alert) bool {
 	return suppressed
 }
 
+// ShouldSuppressNotification checks if an alert notification should be suppressed
+// during quiet hours. Used for paths that bypass dispatchAlert (e.g. escalation).
+func (m *Manager) ShouldSuppressNotification(alert *Alert) bool {
+	if alert == nil {
+		return false
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	suppressed, reason := m.shouldSuppressNotification(alert)
+	if suppressed {
+		log.Debug().
+			Str("alertID", alert.ID).
+			Str("type", alert.Type).
+			Str("level", string(alert.Level)).
+			Str("quietHoursRule", reason).
+			Msg("Escalation notification suppressed during quiet hours")
+	}
+	return suppressed
+}
+
 // shouldNotifyAfterCooldown checks if enough time has passed since the last notification
 // Returns true if notification should be sent, false if still in cooldown period
 func (m *Manager) shouldNotifyAfterCooldown(alert *Alert) bool {

--- a/internal/alerts/quiet_hours_test.go
+++ b/internal/alerts/quiet_hours_test.go
@@ -73,6 +73,31 @@ func TestShouldSuppressNotificationQuietHours(t *testing.T) {
 	})
 }
 
+func TestShouldSuppressNotificationPublic(t *testing.T) {
+	t.Run("nil alert returns false", func(t *testing.T) {
+		m := newManagerWithQuietHoursSuppress(QuietHoursSuppression{Offline: true})
+		if m.ShouldSuppressNotification(nil) {
+			t.Fatal("expected false for nil alert")
+		}
+	})
+
+	t.Run("suppresses offline alert during quiet hours", func(t *testing.T) {
+		m := newManagerWithQuietHoursSuppress(QuietHoursSuppression{Offline: true})
+		alert := &Alert{ID: "offline-esc", Type: "connectivity", Level: AlertLevelCritical}
+		if !m.ShouldSuppressNotification(alert) {
+			t.Fatal("expected offline escalation to be suppressed during quiet hours")
+		}
+	})
+
+	t.Run("does not suppress when offline suppression disabled", func(t *testing.T) {
+		m := newManagerWithQuietHoursSuppress(QuietHoursSuppression{Offline: false})
+		alert := &Alert{ID: "offline-esc2", Type: "connectivity", Level: AlertLevelCritical}
+		if m.ShouldSuppressNotification(alert) {
+			t.Fatal("expected offline escalation not to be suppressed when offline suppression is off")
+		}
+	})
+}
+
 func TestIsInQuietHours(t *testing.T) {
 	// t.Parallel()
 

--- a/internal/monitoring/monitor.go
+++ b/internal/monitoring/monitor.go
@@ -4837,6 +4837,10 @@ func (m *Monitor) Start(ctx context.Context, wsHub *websocket.Hub) {
 
 		escalationLevel := config.Schedule.Escalation.Levels[level-1]
 
+		if m.alertManager.ShouldSuppressNotification(alert) {
+			return
+		}
+
 		// Send notifications only to the channels specified in the escalation level
 		m.notificationMgr.SendAlertToChannels(alert, escalationLevel.Notify)
 

--- a/internal/monitoring/monitor_alert_handling_test.go
+++ b/internal/monitoring/monitor_alert_handling_test.go
@@ -162,3 +162,63 @@ func TestHandleAlertResolved_QuietHoursDoesNotSuppressRecovery(t *testing.T) {
 		t.Fatalf("timed out waiting for resolved notification webhook (should not be suppressed by quiet hours)")
 	}
 }
+
+func TestEscalationCallback_QuietHoursSuppression(t *testing.T) {
+	sent := make(chan struct{}, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case sent <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	notifMgr := notifications.NewNotificationManagerWithDataDir("http://pulse.example", t.TempDir())
+	if err := notifMgr.UpdateAllowedPrivateCIDRs("127.0.0.1/32,::1/128"); err != nil {
+		t.Fatalf("UpdateAllowedPrivateCIDRs: %v", err)
+	}
+	notifMgr.AddWebhook(notifications.WebhookConfig{
+		ID:      "esc-webhook",
+		Name:    "esc-webhook",
+		URL:     srv.URL,
+		Enabled: true,
+		Service: "generic",
+	})
+
+	alertMgr := alerts.NewManager()
+	cfg := alertMgr.GetConfig()
+	cfg.Enabled = true
+	cfg.Schedule.QuietHours.Enabled = true
+	cfg.Schedule.QuietHours.Timezone = "UTC"
+	cfg.Schedule.QuietHours.Days = map[string]bool{
+		"monday": true, "tuesday": true, "wednesday": true,
+		"thursday": true, "friday": true, "saturday": true, "sunday": true,
+	}
+	now := time.Now().UTC()
+	cfg.Schedule.QuietHours.Start = now.Add(-1 * time.Hour).Format("15:04")
+	cfg.Schedule.QuietHours.End = now.Add(1 * time.Hour).Format("15:04")
+	cfg.Schedule.QuietHours.Suppress.Offline = true
+	alertMgr.UpdateConfig(cfg)
+
+	alert := &alerts.Alert{
+		ID:    "esc-offline",
+		Type:  "connectivity",
+		Level: alerts.AlertLevelCritical,
+	}
+	if !alertMgr.ShouldSuppressNotification(alert) {
+		t.Skip("quiet hours not active - cannot test escalation suppression")
+	}
+
+	// Simulate what the escalation callback does after the fix.
+	if !alertMgr.ShouldSuppressNotification(alert) {
+		notifMgr.SendAlertToChannels(alert, "esc-webhook")
+	}
+
+	select {
+	case <-sent:
+		t.Fatal("escalation notification should have been suppressed during quiet hours")
+	case <-time.After(500 * time.Millisecond):
+		// no notification sent - correct
+	}
+}


### PR DESCRIPTION
Fixes #1398

Some code paths were bypassing quiet hours checks on escalations. Added a public `ShouldSuppressNotification()` wrapper so any code path can check the quiet hours rules before notifying. Tests verify the suppression scenarios.