### PR TITLE
Fix SSE stream parser dropping tool calls on EOF

### DIFF
--- a/internal/ai/providers/openai.go
+++ b/internal/ai/providers/openai.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -714,6 +715,47 @@ func (c *OpenAIClient) ChatStream(ctx context.Context, req ChatRequest, callback
 	var inputTokens, outputTokens int
 	var finishReason string
 
+	// emitFinalToolCalls builds ToolCall values from the accumulated stream
+	// deltas, determines the stop reason, and fires the "done" callback.
+	// Called from both the normal [DONE] path and the EOF fallback path.
+	emitFinalToolCalls := func() {
+		// Build tool calls from builders in deterministic index order
+		indices := make([]int, 0, len(toolCallBuilders))
+		for idx := range toolCallBuilders {
+			indices = append(indices, idx)
+		}
+		sort.Ints(indices)
+		for _, idx := range indices {
+			builder := toolCallBuilders[idx]
+			var input map[string]interface{}
+			if err := json.Unmarshal([]byte(builder.args.String()), &input); err != nil {
+				input = map[string]interface{}{"raw": builder.args.String()}
+			}
+			toolCalls = append(toolCalls, ToolCall{
+				ID:    builder.id,
+				Name:  builder.name,
+				Input: input,
+			})
+		}
+
+		stopReason := finishReason
+		if len(toolCalls) > 0 {
+			stopReason = "tool_use"
+		} else if stopReason == "" || stopReason == "stop" {
+			stopReason = "end_turn"
+		}
+
+		callback(StreamEvent{
+			Type: "done",
+			Data: DoneEvent{
+				StopReason:   stopReason,
+				ToolCalls:    toolCalls,
+				InputTokens:  inputTokens,
+				OutputTokens: outputTokens,
+			},
+		})
+	}
+
 	atEOF := false
 	for {
 		n, err := reader.Read(buf)
@@ -750,35 +792,7 @@ func (c *OpenAIClient) ChatStream(ctx context.Context, req ChatRequest, callback
 			data = strings.TrimSpace(data)
 
 			if data == "[DONE]" {
-				// Build final tool calls from builders
-				for _, builder := range toolCallBuilders {
-					var input map[string]interface{}
-					if err := json.Unmarshal([]byte(builder.args.String()), &input); err != nil {
-						input = map[string]interface{}{"raw": builder.args.String()}
-					}
-					toolCalls = append(toolCalls, ToolCall{
-						ID:    builder.id,
-						Name:  builder.name,
-						Input: input,
-					})
-				}
-
-				stopReason := finishReason
-				if len(toolCalls) > 0 {
-					stopReason = "tool_use"
-				} else if stopReason == "stop" {
-					stopReason = "end_turn"
-				}
-
-				callback(StreamEvent{
-					Type: "done",
-					Data: DoneEvent{
-						StopReason:   stopReason,
-						ToolCalls:    toolCalls,
-						InputTokens:  inputTokens,
-						OutputTokens: outputTokens,
-					},
-				})
+				emitFinalToolCalls()
 				return nil
 			}
 
@@ -857,32 +871,7 @@ func (c *OpenAIClient) ChatStream(ctx context.Context, req ChatRequest, callback
 	// If we exited the loop without hitting [DONE] (e.g. server closed connection),
 	// still build and emit any accumulated tool calls so they aren't silently dropped.
 	if len(toolCallBuilders) > 0 && len(toolCalls) == 0 {
-		for _, builder := range toolCallBuilders {
-			var input map[string]interface{}
-			if err := json.Unmarshal([]byte(builder.args.String()), &input); err != nil {
-				input = map[string]interface{}{"raw": builder.args.String()}
-			}
-			toolCalls = append(toolCalls, ToolCall{
-				ID:    builder.id,
-				Name:  builder.name,
-				Input: input,
-			})
-		}
-		stopReason := finishReason
-		if len(toolCalls) > 0 {
-			stopReason = "tool_use"
-		} else if stopReason == "stop" || stopReason == "" {
-			stopReason = "end_turn"
-		}
-		callback(StreamEvent{
-			Type: "done",
-			Data: DoneEvent{
-				StopReason:   stopReason,
-				ToolCalls:    toolCalls,
-				InputTokens:  inputTokens,
-				OutputTokens: outputTokens,
-			},
-		})
+		emitFinalToolCalls()
 	}
 
 	return nil

--- a/internal/ai/providers/openai.go
+++ b/internal/ai/providers/openai.go
@@ -714,16 +714,25 @@ func (c *OpenAIClient) ChatStream(ctx context.Context, req ChatRequest, callback
 	var inputTokens, outputTokens int
 	var finishReason string
 
+	atEOF := false
 	for {
 		n, err := reader.Read(buf)
+		if n > 0 {
+			pendingData += string(buf[:n])
+		}
 		if err != nil {
-			if err == io.EOF {
+			if err != io.EOF {
+				return fmt.Errorf("stream read error: %w", err)
+			}
+			atEOF = true
+			// At EOF, process any remaining pendingData then break
+			if pendingData == "" {
 				break
 			}
-			return fmt.Errorf("stream read error: %w", err)
+			// Ensure trailing data is processed by appending a newline
+			pendingData += "\n"
 		}
 
-		pendingData += string(buf[:n])
 		lines := strings.Split(pendingData, "\n")
 
 		// Keep the last incomplete line for next iteration
@@ -839,6 +848,41 @@ func (c *OpenAIClient) ChatStream(ctx context.Context, req ChatRequest, callback
 				}
 			}
 		}
+
+		if atEOF {
+			break
+		}
+	}
+
+	// If we exited the loop without hitting [DONE] (e.g. server closed connection),
+	// still build and emit any accumulated tool calls so they aren't silently dropped.
+	if len(toolCallBuilders) > 0 && len(toolCalls) == 0 {
+		for _, builder := range toolCallBuilders {
+			var input map[string]interface{}
+			if err := json.Unmarshal([]byte(builder.args.String()), &input); err != nil {
+				input = map[string]interface{}{"raw": builder.args.String()}
+			}
+			toolCalls = append(toolCalls, ToolCall{
+				ID:    builder.id,
+				Name:  builder.name,
+				Input: input,
+			})
+		}
+		stopReason := finishReason
+		if len(toolCalls) > 0 {
+			stopReason = "tool_use"
+		} else if stopReason == "stop" || stopReason == "" {
+			stopReason = "end_turn"
+		}
+		callback(StreamEvent{
+			Type: "done",
+			Data: DoneEvent{
+				StopReason:   stopReason,
+				ToolCalls:    toolCalls,
+				InputTokens:  inputTokens,
+				OutputTokens: outputTokens,
+			},
+		})
 	}
 
 	return nil

--- a/internal/ai/providers/openai_test.go
+++ b/internal/ai/providers/openai_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -125,6 +126,112 @@ func TestOpenAIClient_ChatStream_ToolCall(t *testing.T) {
 	assert.Equal(t, "call_123", toolCalls[0].ID)
 	assert.Equal(t, "get_weather", toolCalls[0].Name)
 	assert.Equal(t, map[string]interface{}{"location": "NYC"}, toolCalls[0].Input)
+}
+
+// eofReader wraps content in a reader that returns n>0 and io.EOF simultaneously
+// on the final Read, simulating servers that close the connection with buffered data.
+type eofReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *eofReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	if r.pos >= len(r.data) {
+		// Return data AND EOF in same call, per io.Reader contract
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *eofReader) Close() error { return nil }
+
+func TestOpenAIClient_ChatStream_ToolCallWithSimultaneousEOF(t *testing.T) {
+	// Simulate a server that returns all SSE data and EOF in the same Read call.
+	// This tests that the parser processes pendingData before breaking on EOF.
+	ssePayload := "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_eof\",\"type\":\"function\",\"function\":{\"name\":\"test_tool\",\"arguments\":\"{\\\"key\\\":\\\"value\\\"}\"}}]}}]}\n\n" +
+		"data: {\"id\":\"1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n" +
+		"data: [DONE]\n\n"
+
+	client := &OpenAIClient{
+		apiKey:  "sk-test",
+		model:   "test-model",
+		baseURL: "http://unused",
+		client: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       &eofReader{data: []byte(ssePayload)},
+					Header:     http.Header{"Content-Type": {"text/event-stream"}},
+				}, nil
+			}),
+		},
+	}
+
+	var toolCalls []ToolCall
+	callback := func(event StreamEvent) {
+		if event.Type == "done" {
+			if data, ok := event.Data.(DoneEvent); ok {
+				toolCalls = data.ToolCalls
+			}
+		}
+	}
+
+	err := client.ChatStream(context.Background(), ChatRequest{Messages: []Message{{Role: "user", Content: "test"}}}, callback)
+	require.NoError(t, err)
+
+	require.Len(t, toolCalls, 1, "Should have 1 tool call even when EOF arrives with data")
+	assert.Equal(t, "call_eof", toolCalls[0].ID)
+	assert.Equal(t, "test_tool", toolCalls[0].Name)
+	assert.Equal(t, map[string]interface{}{"key": "value"}, toolCalls[0].Input)
+}
+
+func TestOpenAIClient_ChatStream_ToolCallWithoutDONE(t *testing.T) {
+	// Simulate a server that sends tool call deltas but closes the connection
+	// without sending [DONE]. The fallback should still emit accumulated tool calls.
+	ssePayload := "data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_nodone\",\"type\":\"function\",\"function\":{\"name\":\"my_tool\",\"arguments\":\"\"}}]}}]}\n\n" +
+		"data: {\"id\":\"1\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"a\\\":1}\"}}]}}]}\n\n" +
+		"data: {\"id\":\"1\",\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n"
+	// Note: no [DONE] event
+
+	client := &OpenAIClient{
+		apiKey:  "sk-test",
+		model:   "test-model",
+		baseURL: "http://unused",
+		client: &http.Client{
+			Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: 200,
+					Body:       &eofReader{data: []byte(ssePayload)},
+					Header:     http.Header{"Content-Type": {"text/event-stream"}},
+				}, nil
+			}),
+		},
+	}
+
+	var toolCalls []ToolCall
+	var stopReason string
+	callback := func(event StreamEvent) {
+		if event.Type == "done" {
+			if data, ok := event.Data.(DoneEvent); ok {
+				toolCalls = data.ToolCalls
+				stopReason = data.StopReason
+			}
+		}
+	}
+
+	err := client.ChatStream(context.Background(), ChatRequest{Messages: []Message{{Role: "user", Content: "test"}}}, callback)
+	require.NoError(t, err)
+
+	require.Len(t, toolCalls, 1, "Should have 1 tool call even without [DONE]")
+	assert.Equal(t, "call_nodone", toolCalls[0].ID)
+	assert.Equal(t, "my_tool", toolCalls[0].Name)
+	assert.Equal(t, map[string]interface{}{"a": float64(1)}, toolCalls[0].Input)
+	assert.Equal(t, "tool_use", stopReason)
 }
 
 func TestOpenAIClient_ChatStream_Errors(t *testing.T) {


### PR DESCRIPTION
## Summary
- Process remaining buffered data when `io.EOF` is received instead of breaking immediately
- Emit accumulated tool calls if the stream ends without a `[DONE]` event
- Handles the case where `Read()` returns both `n > 0` and `io.EOF` per Go's io.Reader contract

## Problem
The SSE read loop in `ChatStream` breaks on `io.EOF` before processing `pendingData`. If the server sends tool call chunks and `[DONE]` in the same TCP segment as the connection close, they are read into the buffer but never parsed. This causes `ChatStream` to return `tool_calls: 0` even though tool calls were received.

## Changes
- `internal/ai/providers/openai.go`: Restructured the SSE read loop to process `pendingData` at EOF before exiting
- Added fallback `done` event emission when `toolCallBuilders` contain data but `[DONE]` was never parsed

## Test plan
- Tested with multiple OpenAI-compatible providers where tool calls were previously dropped
- Verified standard OpenAI streaming continues to work unchanged
- Verified Patrol and Chat assistant tool calling works end-to-end

Fixes #1411

🤖 Generated with [Claude Code](https://claude.com/claude-code)