### PR TITLE
Restore frontend formatting gate

### DIFF
--- a/frontend-modern/src/components/Workloads/__tests__/stackedDiskBarModel.branchcov0712b.test.ts
+++ b/frontend-modern/src/components/Workloads/__tests__/stackedDiskBarModel.branchcov0712b.test.ts
@@ -504,7 +504,9 @@ describe('stackedDiskBarModel (branch coverage 2)', () => {
     it('falls back to the aggregate disk when every listed disk has unknown usage', () => {
       const p = buildStackedDiskBarPresentation(
         {
-          disks: [makeDisk({ mountpoint: '/srv/archive', total: 200, used: 0, free: 0, usage: -1 })],
+          disks: [
+            makeDisk({ mountpoint: '/srv/archive', total: 200, used: 0, free: 0, usage: -1 }),
+          ],
           aggregateDisk: makeDisk({ total: 100, used: 25, free: 75, usage: 25 }),
         },
         400,


### PR DESCRIPTION
## Summary
- apply the repository Prettier layout to one pre-existing long branch-coverage fixture
- restore the Frontend job that is red on exact main
- make no behavior or assertion changes

## Verification
- clean npm ci (0 audit vulnerabilities)
- npm run format:check
- npm test -- --run src/components/Workloads/__tests__/stackedDiskBarModel.branchcov0712b.test.ts (26/26 passed)

This is isolated from merged PR #1708 so each maintenance outcome remains independently reversible.