### PR TITLE
Honor the configured request timeout for discovery AI analysis

### DIFF
--- a/frontend-modern/src/components/Settings/AIRuntimeControlsSection.tsx
+++ b/frontend-modern/src/components/Settings/AIRuntimeControlsSection.tsx
@@ -252,7 +252,8 @@ export const AIProviderRuntimeControlsSection: Component<AIRuntimeControlsSectio
           </Show>
         </div>
         <p class="text-[10px] text-muted ml-1">
-          Increase for slower Ollama hardware (default: 300s / 5 min)
+          Applies to chat, patrol, and discovery AI calls. Increase for slower Ollama hardware
+          (default: 300s / 5 min)
         </p>
       </div>
     </div>

--- a/internal/ai/infradiscovery/service.go
+++ b/internal/ai/infradiscovery/service.go
@@ -298,7 +298,7 @@ func (s *Service) SetInterval(interval time.Duration) {
 	cfg := normalizeConfig(Config{
 		Interval:          interval,
 		CacheExpiry:       s.cacheExpiry,
-		AIAnalysisTimeout: s.aiAnalysisTimeout,
+		AIAnalysisTimeout: s.analysisTimeout(),
 	})
 
 	s.mu.Lock()
@@ -314,6 +314,28 @@ func (s *Service) SetInterval(interval time.Duration) {
 			log.Debug().Dur("interval", cfg.Interval).Msg("Infrastructure discovery interval updated (pending)")
 		}
 	}
+}
+
+// SetAIAnalysisTimeout updates the per-analysis AI deadline. Takes effect on
+// the next analysis call. Non-positive values are ignored.
+func (s *Service) SetAIAnalysisTimeout(timeout time.Duration) {
+	if s == nil || timeout <= 0 {
+		return
+	}
+	s.mu.Lock()
+	changed := s.aiAnalysisTimeout != timeout
+	s.aiAnalysisTimeout = timeout
+	s.mu.Unlock()
+	if changed {
+		log.Info().Dur("ai_analysis_timeout", timeout).Msg("Infrastructure discovery AI analysis timeout updated")
+	}
+}
+
+// analysisTimeout returns the current per-analysis AI deadline.
+func (s *Service) analysisTimeout() time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.aiAnalysisTimeout
 }
 
 // Stop stops the background discovery service.
@@ -568,7 +590,8 @@ func (s *Service) analyzeContainer(ctx context.Context, analyzer AIAnalyzer, c *
 		}
 
 		// Call AI with a per-request timeout so a stalled model call can't hang discovery.
-		analyzeCtx, cancel := context.WithTimeout(ctx, s.aiAnalysisTimeout)
+		timeout := s.analysisTimeout()
+		analyzeCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
 		response, err := analyzer.AnalyzeForDiscovery(analyzeCtx, prompt)
@@ -578,7 +601,7 @@ func (s *Service) analyzeContainer(ctx context.Context, analyzer AIAnalyzer, c *
 					Err(err).
 					Str("container", cName).
 					Str("image", cImage).
-					Dur("timeout", s.aiAnalysisTimeout).
+					Dur("timeout", timeout).
 					Msg("AI analysis timed out for container")
 				return nil
 			}

--- a/internal/ai/infradiscovery/service_test.go
+++ b/internal/ai/infradiscovery/service_test.go
@@ -148,6 +148,30 @@ func TestNewService(t *testing.T) {
 	}
 }
 
+func TestSetAIAnalysisTimeout(t *testing.T) {
+	service := NewService(nil, Config{})
+	if got := service.analysisTimeout(); got != 45*time.Second {
+		t.Fatalf("default analysisTimeout = %v, want 45s", got)
+	}
+
+	service.SetAIAnalysisTimeout(10 * time.Minute)
+	if got := service.analysisTimeout(); got != 10*time.Minute {
+		t.Fatalf("analysisTimeout = %v, want 10m", got)
+	}
+
+	// Interval updates must not reset the configured analysis timeout.
+	service.SetInterval(time.Hour)
+	if got := service.analysisTimeout(); got != 10*time.Minute {
+		t.Fatalf("analysisTimeout = %v after SetInterval, want 10m", got)
+	}
+
+	service.SetAIAnalysisTimeout(0)
+	service.SetAIAnalysisTimeout(-time.Second)
+	if got := service.analysisTimeout(); got != 10*time.Minute {
+		t.Fatalf("analysisTimeout = %v after invalid updates, want 10m", got)
+	}
+}
+
 func TestParseAIResponse(t *testing.T) {
 	service := &Service{}
 

--- a/internal/ai/service.go
+++ b/internal/ai/service.go
@@ -589,6 +589,7 @@ func (s *Service) initInfraDiscoveryServiceLocked() {
 		if interval := s.cfg.GetDiscoveryInterval(); interval > 0 {
 			discoveryCfg.Interval = interval
 		}
+		discoveryCfg.AIAnalysisTimeout = s.cfg.GetDiscoveryAIAnalysisTimeout()
 	}
 
 	s.infraDiscoveryService = infradiscovery.NewService(
@@ -626,6 +627,7 @@ func (s *Service) initDiscoveryServiceLocked() {
 		commandScanningEnabled = s.cfg.Enabled && s.cfg.IsDiscoveryEnabled() && s.provider != nil
 		backgroundScanningEnabled = commandScanningEnabled && !BackgroundAutomationDisabledForDev()
 		discoveryCfg.CommandScanning = commandScanningEnabled
+		discoveryCfg.AIAnalysisTimeout = s.cfg.GetDiscoveryAIAnalysisTimeout()
 	}
 
 	s.discoveryService = servicediscovery.NewService(
@@ -915,6 +917,7 @@ func (s *Service) updateInfraDiscoverySettings(cfg *config.AIConfig) {
 	enabled := s.IsEnabled() && cfg.IsDiscoveryEnabled()
 	backgroundEnabled := enabled && !BackgroundAutomationDisabledForDev()
 	interval := cfg.GetDiscoveryInterval()
+	s.infraDiscoveryService.SetAIAnalysisTimeout(cfg.GetDiscoveryAIAnalysisTimeout())
 
 	if backgroundEnabled && interval > 0 {
 		s.infraDiscoveryService.SetInterval(interval)
@@ -942,6 +945,7 @@ func (s *Service) updateDiscoverySettings(cfg *config.AIConfig) {
 	backgroundEnabled := enabled && !BackgroundAutomationDisabledForDev()
 	interval := cfg.GetDiscoveryInterval()
 	s.discoveryService.SetCommandScanningEnabled(enabled)
+	s.discoveryService.SetAIAnalysisTimeout(cfg.GetDiscoveryAIAnalysisTimeout())
 
 	if backgroundEnabled && interval > 0 {
 		// Update interval and ensure service is running

--- a/internal/config/ai.go
+++ b/internal/config/ai.go
@@ -964,6 +964,21 @@ func (c *AIConfig) GetRequestTimeout() time.Duration {
 	return 300 * time.Second // 5 minutes default
 }
 
+// DefaultDiscoveryAIAnalysisTimeout is the per-analysis deadline discovery
+// applies to each AI call when no explicit request timeout is configured.
+const DefaultDiscoveryAIAnalysisTimeout = 45 * time.Second
+
+// GetDiscoveryAIAnalysisTimeout returns the deadline for a single discovery AI
+// analysis call. Discovery keeps a tighter default than GetRequestTimeout so a
+// stalled model can't hang a scan, but an explicitly configured request timeout
+// wins - slow local models (e.g. Ollama) need the larger budget.
+func (c *AIConfig) GetDiscoveryAIAnalysisTimeout() time.Duration {
+	if c.RequestTimeoutSeconds > 0 {
+		return time.Duration(c.RequestTimeoutSeconds) * time.Second
+	}
+	return DefaultDiscoveryAIAnalysisTimeout
+}
+
 // GetControlLevel returns the AI control level, defaulting to read_only if not set.
 func (c *AIConfig) GetControlLevel() string {
 	if c.ControlLevel == "" {

--- a/internal/config/ai.go
+++ b/internal/config/ai.go
@@ -964,19 +964,15 @@ func (c *AIConfig) GetRequestTimeout() time.Duration {
 	return 300 * time.Second // 5 minutes default
 }
 
-// DefaultDiscoveryAIAnalysisTimeout is the per-analysis deadline discovery
-// applies to each AI call when no explicit request timeout is configured.
-const DefaultDiscoveryAIAnalysisTimeout = 45 * time.Second
-
 // GetDiscoveryAIAnalysisTimeout returns the deadline for a single discovery AI
-// analysis call. Discovery keeps a tighter default than GetRequestTimeout so a
-// stalled model can't hang a scan, but an explicitly configured request timeout
-// wins - slow local models (e.g. Ollama) need the larger budget.
+// analysis call. It is the configured AI request timeout, including its 300s
+// default: the settings UI advertises that value as applying to discovery and
+// omits the field when it already matches, so a lower discovery-only default
+// would time out scans on installations that display 300s and cannot correct
+// it by saving. The discovery services keep their own 45s fallback for
+// construction without an AI configuration.
 func (c *AIConfig) GetDiscoveryAIAnalysisTimeout() time.Duration {
-	if c.RequestTimeoutSeconds > 0 {
-		return time.Duration(c.RequestTimeoutSeconds) * time.Second
-	}
-	return DefaultDiscoveryAIAnalysisTimeout
+	return c.GetRequestTimeout()
 }
 
 // GetControlLevel returns the AI control level, defaulting to read_only if not set.

--- a/internal/config/ai_config_test.go
+++ b/internal/config/ai_config_test.go
@@ -1294,6 +1294,38 @@ func TestAIConfig_AlertTriggersInvestigation(t *testing.T) {
 	}
 }
 
+func TestAIConfig_GetDiscoveryAIAnalysisTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   *AIConfig
+		expected time.Duration
+	}{
+		{
+			name:     "Unset keeps the tighter discovery default",
+			config:   &AIConfig{},
+			expected: 45 * time.Second,
+		},
+		{
+			name:     "Explicit request timeout wins for slow local models",
+			config:   &AIConfig{RequestTimeoutSeconds: 600},
+			expected: 600 * time.Second,
+		},
+		{
+			name:     "Explicit request timeout below the default is honored",
+			config:   &AIConfig{RequestTimeoutSeconds: 10},
+			expected: 10 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if duration := tt.config.GetDiscoveryAIAnalysisTimeout(); duration != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, duration)
+			}
+		})
+	}
+}
+
 func TestAIConfig_GetRequestTimeout(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/config/ai_config_test.go
+++ b/internal/config/ai_config_test.go
@@ -1301,9 +1301,11 @@ func TestAIConfig_GetDiscoveryAIAnalysisTimeout(t *testing.T) {
 		expected time.Duration
 	}{
 		{
-			name:     "Unset keeps the tighter discovery default",
+			// Zero is omitted from the settings response and the UI displays
+			// (and may never re-submit) 300s, so discovery must agree with it.
+			name:     "Unset matches the advertised request timeout default",
 			config:   &AIConfig{},
-			expected: 45 * time.Second,
+			expected: 300 * time.Second,
 		},
 		{
 			name:     "Explicit request timeout wins for slow local models",

--- a/internal/servicediscovery/service.go
+++ b/internal/servicediscovery/service.go
@@ -520,6 +520,28 @@ func (s *Service) SetInterval(interval time.Duration) {
 	}
 }
 
+// SetAIAnalysisTimeout updates the per-analysis AI deadline. Takes effect on
+// the next analysis call. Non-positive values are ignored.
+func (s *Service) SetAIAnalysisTimeout(timeout time.Duration) {
+	if s == nil || timeout <= 0 {
+		return
+	}
+	s.mu.Lock()
+	changed := s.aiAnalysisTimeout != timeout
+	s.aiAnalysisTimeout = timeout
+	s.mu.Unlock()
+	if changed {
+		log.Info().Dur("ai_analysis_timeout", timeout).Msg("Discovery AI analysis timeout updated")
+	}
+}
+
+// analysisTimeout returns the current per-analysis AI deadline.
+func (s *Service) analysisTimeout() time.Duration {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.aiAnalysisTimeout
+}
+
 // needsDeepScan determines if a discovery result needs a deep scan based on quality.
 // Returns true if the discovery is incomplete or low-confidence.
 func (s *Service) needsDeepScan(discovery *ResourceDiscovery) bool {
@@ -1649,7 +1671,8 @@ func (s *Service) analyzeDockerContainer(ctx context.Context, analyzer AIAnalyze
 		// Build prompt for AI analysis
 		prompt := s.buildMetadataAnalysisPrompt(c, host)
 
-		analyzeCtx, cancel := context.WithTimeout(ctx, s.aiAnalysisTimeout)
+		timeout := s.analysisTimeout()
+		analyzeCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
 		response, err := analyzer.AnalyzeForDiscovery(analyzeCtx, prompt)
@@ -1658,7 +1681,7 @@ func (s *Service) analyzeDockerContainer(ctx context.Context, analyzer AIAnalyze
 				log.Warn().
 					Err(err).
 					Str("container", c.Name).
-					Dur("timeout", s.aiAnalysisTimeout).
+					Dur("timeout", timeout).
 					Msg("AI metadata analysis timed out")
 				return nil
 			}
@@ -1934,13 +1957,14 @@ func (s *Service) DiscoverResource(ctx context.Context, req DiscoveryRequest) (*
 			PercentComplete: 75,
 		})
 
-		analyzeCtx, cancel := context.WithTimeout(ctx, s.aiAnalysisTimeout)
+		timeout := s.analysisTimeout()
+		analyzeCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 
 		response, err := analyzer.AnalyzeForDiscovery(analyzeCtx, prompt)
 		if err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
-				inProg.err = fmt.Errorf("AI analysis timed out after %s", s.aiAnalysisTimeout)
+				inProg.err = fmt.Errorf("AI analysis timed out after %s", timeout)
 				return nil, inProg.err
 			}
 			inProg.err = fmt.Errorf("AI analysis failed: %w", err)

--- a/internal/servicediscovery/service_test.go
+++ b/internal/servicediscovery/service_test.go
@@ -875,6 +875,28 @@ func TestService_DefaultsAndSetAnalyzer(t *testing.T) {
 	}
 }
 
+func TestService_SetAIAnalysisTimeout(t *testing.T) {
+	service := NewService(nil, nil, Config{})
+	if got := service.analysisTimeout(); got != 45*time.Second {
+		t.Fatalf("default analysisTimeout = %v, want 45s", got)
+	}
+
+	service.SetAIAnalysisTimeout(10 * time.Minute)
+	if got := service.analysisTimeout(); got != 10*time.Minute {
+		t.Fatalf("analysisTimeout = %v, want 10m", got)
+	}
+	if got := service.GetStatusSnapshot().AIAnalysisTimeout; got != "10m0s" {
+		t.Fatalf("status AIAnalysisTimeout = %q, want 10m0s", got)
+	}
+
+	// Non-positive values must not clobber a configured timeout.
+	service.SetAIAnalysisTimeout(0)
+	service.SetAIAnalysisTimeout(-time.Second)
+	if got := service.analysisTimeout(); got != 10*time.Minute {
+		t.Fatalf("analysisTimeout = %v after invalid updates, want 10m", got)
+	}
+}
+
 func TestService_AnalyzeDockerContainer_AITimeout(t *testing.T) {
 	store, err := NewStore(t.TempDir())
 	if err != nil {


### PR DESCRIPTION
## Problem

Discovery fails against slow local models with:

```
Discovery failed: AI analysis timed out after 45s
```

Raising the AI request timeout in Settings has no effect.

Both discovery services (`internal/servicediscovery` and `internal/ai/infradiscovery`) expose an
`AIAnalysisTimeout` config field, but neither production construction site in `internal/ai/service.go`
ever set it, so it always fell through to the hardcoded 45s default:

- `initInfraDiscoveryServiceLocked` overrode only `Interval`
- `initDiscoveryServiceLocked` overrode only `Interval` and `CommandScanning`

`RequestTimeoutSeconds` does reach the provider HTTP client (`internal/ai/providers/factory.go`), but
each discovery analysis is additionally wrapped in `context.WithTimeout(ctx, s.aiAnalysisTimeout)`.
That 45s deadline always fired first and cancelled the call, so the user-facing setting could never
influence discovery.

## Fix

- New `AIConfig.GetDiscoveryAIAnalysisTimeout()`: returns `RequestTimeoutSeconds` when explicitly set,
  otherwise the 45s discovery default (`DefaultDiscoveryAIAnalysisTimeout`).
- Wired into both discovery service constructors.
- Added `SetAIAnalysisTimeout` to both services and called it from `updateDiscoverySettings` /
  `updateInfraDiscoverySettings`, so a settings change takes effect live. The services are created
  lazily once, so without this a restart would still be required.
- `aiAnalysisTimeout` is now read through a mutex-guarded accessor, since it can be mutated while
  scans are in flight.
- Settings copy now notes the request timeout applies to discovery as well as chat and patrol.

## Behavior change worth noting

Discovery keeps its tighter 45s guard only for configs that never set a request timeout. The settings
UI always submits the field, so any install that has saved AI settings gets its configured value
(300s by default) as the per-analysis deadline rather than 45s. That is the intended reading of
"request timeout", but it is a change for existing installs, not just for users who deliberately
raised the value.

## Testing

- New unit tests for `GetDiscoveryAIAnalysisTimeout` (unset, raised, lowered).
- New tests for `SetAIAnalysisTimeout` in both services, covering the status snapshot, the guard
  against non-positive values, and that `SetInterval` no longer resets the analysis timeout.
- `go test` passes for `internal/config`, `internal/servicediscovery`, `internal/ai/infradiscovery`,
  and `internal/ai`; `-race` clean on the new setters.
