### PR TITLE
Resolve discovery lookups across forked host identities

### DIFF
--- a/internal/servicediscovery/service.go
+++ b/internal/servicediscovery/service.go
@@ -3011,6 +3011,15 @@ func (s *Service) GetDiscoveryByResource(resourceType ResourceType, targetID, re
 		ResourceID:   resourceID,
 	}
 	aliasIDs := []string{MakeResourceID(resourceType, targetID, resourceID)}
+	// A forked host identity is not reachable through normalizeDiscoveryRequest,
+	// which only matches exact snapshot IDs and hostnames. Seed the equivalent
+	// spellings of the target so records stored under a fork still resolve.
+	for _, candidate := range s.equivalentDiscoveryTargetIDs(targetID) {
+		aliasIDs = append(aliasIDs, MakeResourceID(resourceType, candidate, candidate))
+		if resourceID != "" && resourceID != candidate {
+			aliasIDs = append(aliasIDs, MakeResourceID(resourceType, candidate, resourceID))
+		}
+	}
 	req = s.normalizeDiscoveryRequest(req, &aliasIDs)
 
 	d, err := s.store.GetByResource(resourceType, req.TargetID, req.ResourceID)
@@ -3067,16 +3076,144 @@ func (s *Service) ListDiscoveriesByType(resourceType ResourceType) ([]*ResourceD
 }
 
 // ListDiscoveriesByTarget returns discoveries for a specific target ID.
+//
+// The store matches TargetID byte-for-byte, but callers legitimately hold a
+// different spelling of the same target than the record was stored under: a PVE
+// node reports its linked agent by base agent UUID while the host record itself
+// may have forked onto a suffixed identity. Resolve the request through
+// equivalentDiscoveryTargetIDs so those spellings still find their records.
 func (s *Service) ListDiscoveriesByTarget(targetID string) ([]*ResourceDiscovery, error) {
-	discoveries, err := s.store.ListByTarget(targetID)
+	candidates := s.equivalentDiscoveryTargetIDs(targetID)
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	all, err := s.store.List()
 	if err != nil {
 		return nil, fmt.Errorf("list discoveries by target %q: %w", targetID, err)
 	}
+
+	wanted := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		wanted[candidate] = struct{}{}
+	}
+
+	discoveries := make([]*ResourceDiscovery, 0, len(all))
+	for _, d := range all {
+		if d == nil {
+			continue
+		}
+		if _, ok := wanted[strings.TrimSpace(d.TargetID)]; ok {
+			discoveries = append(discoveries, d)
+		}
+	}
+
 	discoveries = s.deduplicateDiscoveries(discoveries)
 	for _, d := range discoveries {
 		s.upgradeCLIAccessIfNeeded(d)
 	}
 	return discoveries, nil
+}
+
+// equivalentDiscoveryTargetIDs returns every target ID that identifies the same
+// target as targetID, starting with targetID itself.
+//
+// Host identities fork onto a "<base>-<hex suffix>" form when an agent re-enrolls
+// under a new token against an existing record (see the host token binding logic
+// in internal/monitoring) - re-running an install with --proxmox is enough to
+// trigger it. Discovery then stores records under the forked host ID while the
+// PVE node still reports the base agent UUID as its linked agent, so a lookup by
+// base UUID finds nothing. Bridge the two through the live snapshot.
+func (s *Service) equivalentDiscoveryTargetIDs(targetID string) []string {
+	trimmed := strings.TrimSpace(targetID)
+	if trimmed == "" {
+		return nil
+	}
+
+	ids := []string{trimmed}
+	seen := map[string]struct{}{trimmed: {}}
+	add := func(id string) {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return
+		}
+		if _, ok := seen[id]; ok {
+			return
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	snap, ok := s.getSnapshot()
+	if !ok {
+		return ids
+	}
+
+	// Hostnames that name the requested target. A forked host ID is otherwise
+	// unreachable from the base UUID, but it still reports the same hostname.
+	hostnames := make(map[string]struct{})
+	noteHostname := func(hostname string) {
+		hostname = strings.TrimSpace(hostname)
+		if hostname != "" {
+			hostnames[hostname] = struct{}{}
+		}
+	}
+
+	for _, node := range snap.Nodes {
+		if node.LinkedAgentID == trimmed || node.ID == trimmed || node.Name == trimmed {
+			add(node.LinkedAgentID)
+			add(node.Name)
+			noteHostname(node.Name)
+		}
+	}
+	for _, host := range snap.Hosts {
+		if host.ID == trimmed || host.Hostname == trimmed {
+			noteHostname(host.Hostname)
+		}
+	}
+
+	for _, host := range snap.Hosts {
+		switch {
+		case host.ID == trimmed:
+			add(host.Hostname)
+		case host.Hostname != "" && host.Hostname == trimmed:
+			add(host.ID)
+		case isForkedHostIdentity(host.ID, trimmed):
+			add(host.ID)
+		default:
+			if _, ok := hostnames[strings.TrimSpace(host.Hostname)]; ok && host.Hostname != "" {
+				add(host.ID)
+			}
+		}
+	}
+
+	return ids
+}
+
+// isForkedHostIdentity reports whether candidate is base carrying one or more
+// host-identity fork suffixes. Forks append "-<hex>", and a base longer than 40
+// characters is truncated before the next suffix is appended, so a twice-forked
+// identity carries a partial suffix followed by a full one. Requiring every
+// trailing segment to be hex keeps unrelated IDs that merely share a prefix out.
+func isForkedHostIdentity(candidate, base string) bool {
+	if candidate == "" || base == "" || candidate == base {
+		return false
+	}
+	tail, ok := strings.CutPrefix(candidate, base+"-")
+	if !ok {
+		return false
+	}
+	for _, segment := range strings.Split(tail, "-") {
+		if segment == "" {
+			return false
+		}
+		for _, r := range segment {
+			if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // deduplicateDiscoveries filters out redundant discoveries where a PVE node

--- a/internal/servicediscovery/service_test.go
+++ b/internal/servicediscovery/service_test.go
@@ -2433,3 +2433,160 @@ func TestService_DiscoverResource_ReturnsUpgradedCachedDiscovery(t *testing.T) {
 		t.Fatalf("expected cleaned AI reasoning without legacy URL note, got %q", got.AIReasoning)
 	}
 }
+
+// Regression: a host identity that forked onto a "<base>-<hex>" spelling (an
+// agent re-enrolling under a new token against an existing record) stored its
+// discovery under the forked host ID, while the PVE node kept reporting the base
+// agent UUID as its linked agent. The store matches TargetID byte-for-byte, so
+// the resource drawer's list-by-agent call returned an empty 200 and the
+// Discovery tab reported "no saved discovery run" for a host it had analyzed.
+func TestService_ListDiscoveriesByTarget_ResolvesForkedHostIdentity(t *testing.T) {
+	const baseAgentID = "342f337b-d2a9-4316-a998-d09a2abe3e8f"
+	const forkedAgentID = baseAgentID + "-bffd0339"
+
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore error: %v", err)
+	}
+	store.crypto = nil
+
+	service := NewService(store, nil, DefaultConfig())
+	service.SetReadState(readStateFromSnapshot(StateSnapshot{
+		Hosts: []Host{{ID: forkedAgentID, Hostname: "nova.biz", Status: "online"}},
+		Nodes: []Node{{ID: "node-nova", Name: "nova", LinkedAgentID: baseAgentID}},
+	}))
+
+	discovery := &ResourceDiscovery{
+		ID:           MakeResourceID(ResourceTypeAgent, forkedAgentID, forkedAgentID),
+		ResourceType: ResourceTypeAgent,
+		TargetID:     forkedAgentID,
+		ResourceID:   forkedAgentID,
+		Hostname:     "nova.biz",
+		ServiceType:  "proxmox",
+	}
+	if err := store.Save(discovery); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+
+	got, err := service.ListDiscoveriesByTarget(baseAgentID)
+	if err != nil {
+		t.Fatalf("ListDiscoveriesByTarget error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 discovery for base agent ID, got %d", len(got))
+	}
+	if got[0].TargetID != forkedAgentID {
+		t.Fatalf("TargetID = %q, want %q", got[0].TargetID, forkedAgentID)
+	}
+
+	// The forked spelling must keep working, as must the single-record path.
+	if direct, err := service.ListDiscoveriesByTarget(forkedAgentID); err != nil || len(direct) != 1 {
+		t.Fatalf("ListDiscoveriesByTarget(forked) = %d discoveries, err %v; want 1, nil", len(direct), err)
+	}
+	byResource, err := service.GetDiscoveryByResource(ResourceTypeAgent, baseAgentID, baseAgentID)
+	if err != nil {
+		t.Fatalf("GetDiscoveryByResource error: %v", err)
+	}
+	if byResource == nil || byResource.TargetID != forkedAgentID {
+		t.Fatalf("GetDiscoveryByResource returned %#v, want the forked record", byResource)
+	}
+}
+
+// A base longer than 40 characters is truncated before the next fork suffix is
+// appended, so a twice-forked identity carries a partial suffix then a full one.
+func TestService_ListDiscoveriesByTarget_ResolvesTwiceForkedHostIdentity(t *testing.T) {
+	const baseAgentID = "ea79df24-0d3b-453f-8ce0-cc08e2b96f86"
+	const forkedAgentID = baseAgentID + "-d3b-83adbde6"
+
+	store, err := NewStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStore error: %v", err)
+	}
+	store.crypto = nil
+
+	service := NewService(store, nil, DefaultConfig())
+	service.SetReadState(readStateFromSnapshot(StateSnapshot{
+		Hosts: []Host{{ID: forkedAgentID, Hostname: "luna.vp.diskiller.net", Status: "online"}},
+	}))
+
+	if err := store.Save(&ResourceDiscovery{
+		ID:           MakeResourceID(ResourceTypeAgent, forkedAgentID, forkedAgentID),
+		ResourceType: ResourceTypeAgent,
+		TargetID:     forkedAgentID,
+		ResourceID:   forkedAgentID,
+		Hostname:     "luna.vp.diskiller.net",
+		ServiceType:  "proxmox",
+	}); err != nil {
+		t.Fatalf("Save error: %v", err)
+	}
+
+	got, err := service.ListDiscoveriesByTarget(baseAgentID)
+	if err != nil {
+		t.Fatalf("ListDiscoveriesByTarget error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 discovery for twice-forked identity, got %d", len(got))
+	}
+}
+
+// Target expansion must not sweep in unrelated hosts that merely share a prefix,
+// and must stay quiet when no snapshot is available.
+func TestService_EquivalentDiscoveryTargetIDs_Bounds(t *testing.T) {
+	const baseAgentID = "342f337b-d2a9-4316-a998-d09a2abe3e8f"
+
+	service := NewService(nil, nil, DefaultConfig())
+	if got := service.equivalentDiscoveryTargetIDs(baseAgentID); len(got) != 1 || got[0] != baseAgentID {
+		t.Fatalf("without a snapshot, expected only the requested ID, got %#v", got)
+	}
+	if got := service.equivalentDiscoveryTargetIDs("   "); got != nil {
+		t.Fatalf("expected nil for a blank target, got %#v", got)
+	}
+
+	service.SetReadState(readStateFromSnapshot(StateSnapshot{
+		Hosts: []Host{
+			{ID: baseAgentID + "-bffd0339", Hostname: "nova.biz", Status: "online"},
+			{ID: baseAgentID + "-replica", Hostname: "clone.biz", Status: "online"},
+			{ID: "unrelated-agent", Hostname: "other.biz", Status: "online"},
+		},
+	}))
+
+	got := service.equivalentDiscoveryTargetIDs(baseAgentID)
+	for _, unwanted := range []string{baseAgentID + "-replica", "unrelated-agent"} {
+		for _, id := range got {
+			if id == unwanted {
+				t.Fatalf("expansion pulled in %q: %#v", unwanted, got)
+			}
+		}
+	}
+	var sawFork bool
+	for _, id := range got {
+		if id == baseAgentID+"-bffd0339" {
+			sawFork = true
+		}
+	}
+	if !sawFork {
+		t.Fatalf("expansion missed the hex-suffixed fork: %#v", got)
+	}
+}
+
+func TestIsForkedHostIdentity(t *testing.T) {
+	const base = "342f337b-d2a9-4316-a998-d09a2abe3e8f"
+	tests := []struct {
+		candidate string
+		want      bool
+	}{
+		{base + "-bffd0339", true},
+		{base + "-d3b-83adbde6", true},
+		{base, false},
+		{base + "-replica", false},
+		{base + "-", false},
+		{base + "-bffd0339-", false},
+		{"other-" + base, false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isForkedHostIdentity(tt.candidate, base); got != tt.want {
+			t.Errorf("isForkedHostIdentity(%q, base) = %v, want %v", tt.candidate, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The Discovery tab reports "No saved discovery run for this resource" for a host that has
been successfully analyzed, with the record sitting intact on disk. Running discovery again
displays results immediately (the tab renders the POST response), but navigating away and
back reports nothing again.

Observed on three standalone PVE hosts. The records exist and are individually retrievable:

```
GET /api/discovery/agent/342f337b-d2a9-4316-a998-d09a2abe3e8f-bffd0339/342f337b-...-bffd0339
-> full record, service_type "proxmox", confidence 0.98
```

But the call the resource drawer actually makes returns empty:

```
GET /api/discovery/agent/342f337b-d2a9-4316-a998-d09a2abe3e8f
-> {"agentId":"342f337b-...-8e3f","discoveries":[],"total":0}
```

Note the `-bffd0339`. The record is keyed by a **forked host identity**; the drawer asks by
**base agent UUID**.

## Root cause

Two halves.

**Host identities fork.** `internal/monitoring/monitor_agents.go` forks a host onto
`<base>-<hex suffix>` when an incoming report collides with an existing record under a
different token/hostname, to stay safe against cloned VMs sharing a machine ID (#1584,
with the rename heal-back from #1667):

```go
seed := strings.Join([]string{tokenID, hostname, bindingID}, "|")
sum := sha1.Sum([]byte(seed))
suffix := hex.EncodeToString(sum[:4])
bindingID = fmt.Sprintf("%s-%s", base, suffix)
```

Re-running an agent install with `--proxmox` is enough to trigger it: same machine, same
hostname, new token. Discovery then stores under the forked host ID (normalization resolves
the request to `host.ID`), while the PVE node keeps reporting the **base** agent UUID as its
`LinkedAgentID` - which is what the frontend uses for lookups.

**The list path does no resolution.** `Store.ListByTarget` matches byte-for-byte:

```go
if strings.TrimSpace(d.TargetID) == targetID {
```

`GetDiscoveryByResource` runs `normalizeDiscoveryRequest` and retries against alias IDs, but
`ListDiscoveriesByTarget` -> `Store.ListByTarget` has none of that. It returns an empty
`200`, so nothing surfaces as an error anywhere - the tab just says "not run".

Normalization alone would not have helped either: a base UUID matches neither `host.ID` nor
`host.Hostname` for a forked host, so `GetDiscoveryByResource` misses too.

## Fix

Add `Service.equivalentDiscoveryTargetIDs`, which expands a requested target ID into every
spelling that identifies the same target, using the live snapshot:

- the requested ID itself (always first)
- a host matched by exact ID or hostname
- a host whose ID is the requested ID carrying fork suffixes
- hosts sharing a hostname with the requested target, including via a node's
  `LinkedAgentID` / `Name`

`ListDiscoveriesByTarget` now filters one `store.List()` pass against that set (also
avoiding the repeated full scans a per-candidate `ListByTarget` loop would cost), and
`GetDiscoveryByResource` seeds the same spellings into its alias list so the single-record
path resolves a fork too.

Fork detection requires every trailing segment past the base to be hex, so unrelated IDs
that merely share a prefix are not swept in. It handles the twice-forked shape as well: a
base over 40 characters is truncated before the next suffix is appended, which is why one of
the affected hosts reads `<uuid>-d3b-83adbde6` - an amputated first suffix plus a full
second one.

## Alternatives considered

This fixes the lookup rather than the identity. Two other angles a maintainer may prefer:

- **Heal the fork.** The heal-back path only fires once the pre-rename record has clearly
  stopped reporting; a re-enrollment under a new token may hold the fork in place
  indefinitely.
- **Have the frontend ask by unified host ID.** That means the resource payload consistently
  exposing the forked identity rather than the base agent UUID, which is a broader change to
  resource identity plumbing.

Fixing the lookup is additive and closes the whole class regardless of why a target has more
than one valid spelling, so it seemed the safest starting point. Happy to redirect.

## Testing

New regression tests in `internal/servicediscovery`:

- forked identity resolves via list-by-target, with the forked spelling and the
  single-record path still working
- twice-forked (truncated base) identity resolves
- expansion bounds: no snapshot returns only the requested ID, blank input returns nil, and
  neither a non-hex `-replica` sibling nor an unrelated host is pulled in
- `isForkedHostIdentity` table test covering suffix shapes and rejections

`go test ./internal/servicediscovery/ ./internal/api/` passes.
