### PR TITLE
Harden audit evidence domains and assurance semantics

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -711,7 +711,11 @@ Response:
       "path": "/api/login",
       "success": true,
       "details": "Successful login",
-      "signature": "..."
+      "signature": "v3:...",
+      "signature_version": "v3",
+      "signature_status": "strong",
+      "signature_assurance": "strong",
+      "signature_valid": true
     }
   ],
   "total": 1,
@@ -727,9 +731,30 @@ Response:
 {
   "available": true,
   "verified": true,
-  "message": "Event signature verified"
+  "status": "strong",
+  "version": "v3",
+  "assurance": "strong",
+  "message": "Event signature strongly verified"
 }
 ```
+
+`status` and `assurance` are authoritative. `verified` and per-event
+`signature_valid` remain compatibility fields: both `strong` current evidence
+and `compatibility` historical evidence can have a value of `true`. Clients
+must not turn the boolean alone into a green or current-assurance result.
+
+The complete status set is `strong`, `compatibility`, `invalid`, `unknown`, and
+`unsigned`. Versions are `v3`, `v2`, `legacy`, `unknown`, and `unsigned`.
+Unknown/malformed envelopes do not fall back into historical verification.
+
+### Export and Summary
+
+- `GET /api/audit/export?format=json|csv&verify=true` includes signature
+  version, status, and assurance. The compatibility boolean is also retained.
+- `GET /api/audit/summary` returns separate
+  `strong_signature_count`, `compatibility_signature_count`,
+  `invalid_signature_count`, `unknown_signature_count`, and
+  `unsigned_signature_count` totals.
 
 ### Validate API Token (Admin)
 `POST /api/security/validate-token`

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -34,6 +34,7 @@ Pulse automatically captures the following events:
 | `agent_config_fetch` | Agent configuration retrieval attempts | Agent config fetched successfully |
 
 Each event includes:
+
 - **Timestamp** (UTC)
 - **Event type**
 - **User** who triggered the event
@@ -98,7 +99,7 @@ The export includes all events matching the current filter criteria.
 
 ## Tamper Detection
 
-Every audit event is cryptographically signed at creation time. You can verify that an event has not been modified:
+Current audit events are cryptographically signed at creation time. Verification reports both whether the retained bytes match and what integrity claim that signature format can support:
 
 ```bash
 curl http://localhost:7655/api/audit/6b3c9c3c-9a2f-4b3c-9a3b-3d0e8c5c5d45/verify \
@@ -110,11 +111,33 @@ Response:
 {
   "available": true,
   "verified": true,
-  "message": "Event signature verified"
+  "status": "strong",
+  "version": "v3",
+  "assurance": "strong",
+  "message": "Event signature strongly verified"
 }
 ```
 
-If `verified` is `false`, the event data has been tampered with since it was recorded.
+`status` and `assurance` are authoritative. `verified` is retained for older clients and is `true` for both `strong` and `compatibility`; it must not be used to present those states as equivalent.
+
+| Status | Meaning |
+|--------|---------|
+| `strong` | A valid current `v3` signature with injective field encoding and a version-specific HMAC key domain. |
+| `compatibility` | A valid historical `v2` or unprefixed legacy signature. The bytes match an accepted historical format, but that format does not support the current integrity claim. |
+| `invalid` | A known signature format did not verify. Treat the evidence as failed integrity validation. |
+| `unknown` | The envelope is malformed or unsupported, or verification key material is unavailable. Do not retry it under an older format. |
+| `unsigned` | No signature was retained. |
+
+The list API returns `signature_version`, `signature_status`, and `signature_assurance` on every row. JSON and CSV exports include the version and, with `verify=true`, the status and assurance. Summaries separately count strong, compatibility, invalid, unknown, and unsigned evidence. The UI reserves the green **Strongly verified** state for `strong`; compatibility history is amber and explicitly lower assurance.
+
+### Signature versions and compatibility
+
+- `v3:<64 hex digits>` is the current format. Its authenticated message contains the `v3` domain and envelope, an injective length-prefixed representation of every signed string, the exact persisted Unix-second timestamp and success byte, and the retained historical timestamp-evidence field. Its HMAC-SHA256 key is derived from the instance master audit key under the dedicated `pulse.audit.hmac-key\0v3\0` domain. Removing or changing the envelope cannot move the digest into the accepted `v2` or legacy key domain.
+- `v2:<64 hex digits>` uses injective fields but shares the historical master-key domain, so it is compatibility evidence only.
+- An unprefixed 64-hex signature may match one of three historical delimiter-separated encodings. Those encodings have ambiguous string boundaries, so a match is compatibility evidence only.
+- Any other envelope or malformed MAC is `unknown`. Verification dispatch never falls back from a failed prefixed version into an older representation.
+
+Signatures are opaque versioned strings, not fixed-length bare hex fields. The repository has no supported audit consumer that should assume 64 or 67 characters. Webhook/SIEM clients should retain the signature and the explicit version/assurance fields unchanged and use Pulse's verification endpoint for the authoritative result.
 
 ---
 
@@ -153,9 +176,14 @@ Audit events are stored in a SQLite database in the Pulse data directory:
 - **Multi-tenant:** `{data-dir}/orgs/{org-id}/audit/audit.db`
 
 Data directory locations:
+
 - systemd: `/etc/pulse/`
 - Docker/Kubernetes: `/data/`
 - Development: `tmp/dev-config/`
+
+At startup, Pulse transactionally migrates older audit tables to a strict canonical schema. All signed strings are non-null SQLite `TEXT`, timestamps and success flags are canonical `INTEGER` values, and success is restricted to `0` or `1`. Reads validate raw SQLite storage classes and fail closed on alternate integers, nulls, blobs, reals, or noncanonical timestamp evidence instead of verifying a lossy Go projection.
+
+Historical textual timestamps are normalized for ordering while their canonical RFC3339Nano form is retained separately as signature evidence. This preserves genuine fractional legacy timestamps through migration and restart. Pulse never replaces or re-signs a historical signature. A row that was migrated by an older release after its fractional timestamp material had already been discarded remains `invalid` or otherwise lower assurance; the new migration does not invent evidence or upgrade it. A malformed mixed dataset rolls back as one transaction, leaving the original table and rows intact.
 
 ---
 

--- a/docs/WEBHOOKS.md
+++ b/docs/WEBHOOKS.md
@@ -124,7 +124,24 @@ Pro, legacy Pro+, and Cloud support dedicated audit webhooks for security event 
 2. Add your endpoint URL (e.g., `https://siem.corp.local/ingest/pulse`).
 
 ### Security
-Audit webhooks are dispatched asynchronously. The payload includes a `signature` field which can be verified using the per-instance HMAC key stored (encrypted) at `.audit-signing.key` in the Pulse data directory. There is no `PULSE_AUDIT_SIGNING_KEY` override.
+Audit webhooks are dispatched asynchronously. The envelope contains
+`signature_version`, `signature_status`, and `signature_assurance`; its
+`data.signature` is an opaque versioned value. Pulse verifies each event before
+making an assurance claim. New deliveries use `v3`/`strong`/`strong`. A valid
+historical `v2` or unprefixed signature is labelled `compatibility`, never
+strong; an event delivered without an authoritative verifier is `unknown` with
+`none` assurance.
+
+Use `GET /api/audit/<id>/verify` for the authoritative status. Do not treat a
+successful historical boolean result as current assurance, strip or substitute
+the signature prefix, or retry an unknown version as legacy. Core-managed
+instances keep the per-instance master audit key encrypted at
+`.audit-signing.key`; the encrypted file is not raw HMAC material. Pulse Pro can
+instead supply externally managed key material through
+`PULSE_AUDIT_SIGNING_KEY`; treat that value as a high-entropy secret. Pulse does
+not expose raw key material through this webhook contract. External receivers
+should retain the full payload and its explicit version, status, and assurance
+fields rather than assuming a fixed signature length.
 
 ## 🏢 Provider-hosted MSP webhooks
 

--- a/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
+++ b/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
@@ -15,6 +15,13 @@
 
 ## Purpose
 
+The shared authenticated API router also composes Enterprise audit defaults.
+Audit list and verification routes must preserve the core logger's
+authoritative signature version, status, and assurance when those defaults are
+non-nil; the Enterprise extension may not replace that production composition
+with a boolean-only fallback. This adjacent security projection grants no
+agent enrollment, update, reporting, profile, command, or fleet authority.
+
 Agent-profile assignment presents one actionable identity per connected host.
 When a PBS or PMG provider resource projects an agent ID that is not an active
 host-telemetry surface control, the provider projection is excluded so the

--- a/docs/release-control/v6/internal/subsystems/api-contracts.md
+++ b/docs/release-control/v6/internal/subsystems/api-contracts.md
@@ -20,6 +20,14 @@
 
 ## Purpose
 
+Audit evidence APIs expose `signature_version`, `signature_status`, and
+`signature_assurance` as the authoritative contract. The status vocabulary is
+`strong`, `compatibility`, `invalid`, `unknown`, and `unsigned`; compatibility
+booleans may remain for older clients but must never collapse historical v2 or
+legacy evidence into current strong verification. List, single-event verify,
+JSON/CSV export, and summary projections must use the same classification and
+fail closed for malformed or unsupported envelopes.
+
 Browser WebSocket shutdown distinguishes ordinary client lifecycle from
 transport failure. Normal closure, navigation/going-away, and abnormal closure
 codes used by disconnected clients are informational; policy violations and

--- a/docs/release-control/v6/internal/subsystems/frontend-primitives.md
+++ b/docs/release-control/v6/internal/subsystems/frontend-primitives.md
@@ -22,6 +22,13 @@
 
 Own reusable frontend primitives and canonical page-shell patterns so feature
 work extends shared components instead of creating new local variants.
+The Audit Log settings surface composes those primitives while retaining the
+server's evidence classification. Current strong verification is green,
+historical compatibility is amber, invalid evidence is red, unknown evidence
+is distinct from failure, and unsigned evidence remains neutral. Filters,
+totals, tooltips, projected batch state, and retry actions must use the same
+five-state vocabulary; neither a true compatibility boolean nor an envelope
+prefix alone may render a green current-assurance result.
 The alert schedule's initial-delivery selector composes `SettingsPanel` and
 `FormSelect`, uses the shared alert-configuration presentation vocabulary, and
 exposes the same email, webhook, Apprise, and all-destination labels used by

--- a/docs/release-control/v6/internal/subsystems/security-privacy.md
+++ b/docs/release-control/v6/internal/subsystems/security-privacy.md
@@ -963,17 +963,27 @@ startup, the configured cleanup cadence is preserved across the enterprise
 configuration seam, and cleanup must tolerate concurrent writers without
 exposing partial results. Existing core and Pro signing keys remain valid
 through upgrade. Every new global and tenant SQLite row must carry a
-self-identifying `v2:` HMAC-SHA256 signature over the domain-separated,
+self-identifying `v3:` HMAC-SHA256 signature over the domain-separated,
 length-prefixed persisted tuple (ID, Unix-second timestamp, event type, user,
-IP, path, success, and details). Arbitrary string bytes, including pipes,
-empty values, Unicode, and newlines, must retain injective field boundaries.
+IP, path, success, details, and retained historical timestamp evidence).
+Arbitrary string bytes, including pipes, empty values, Unicode, and newlines,
+must retain injective field boundaries. The v3 envelope is authenticated and
+the MAC key is derived under a v3-specific key domain, so stripping or
+substituting the prefix cannot move a digest into an accepted v2 or legacy
+message/key domain.
 Verification dispatches by the signature envelope: unknown or malformed
-versions fail closed, and a v2 signature is never retried against a historical
-representation. Unprefixed 64-hex signatures remain explicitly identifiable
-as legacy and may verify against the three previously accepted encodings for
-read/export compatibility, but that result proves only the historical MAC and
-must not be represented as providing v2 boundary integrity. Startup and reads
-must not rewrite or re-sign those historical rows.
+versions fail closed, and a prefixed signature is never retried against a
+historical representation. V2 and unprefixed 64-hex legacy signatures remain
+readable for compatibility, but a match is explicitly lower assurance and
+must not be represented as current strong verification. Strong,
+compatibility, invalid, unknown, and unsigned evidence remain distinct through
+core and Enterprise list/verify routes, exports, summaries, and the UI.
+Startup and reads must not rewrite or re-sign historical rows. Schema-v3
+migration retains canonical RFC3339Nano timestamp evidence for historical
+textual rows before normalizing their query timestamp, uses a strict SQLite
+schema for every authenticated field, and validates raw storage classes on
+read. A malformed mixed migration rolls back without publishing a partial
+replacement table or upgrading retained evidence.
 That shared token-management boundary now also includes
 `frontend-modern/src/utils/apiTokenPresentation.ts`, so API-token load,
 generate, and revoke errors stay on one governed customer-facing wording path

--- a/docs/release-control/v6/internal/subsystems/storage-recovery.md
+++ b/docs/release-control/v6/internal/subsystems/storage-recovery.md
@@ -21,6 +21,17 @@
 
 ## Purpose
 
+The shared audit SQLite store is a security persistence boundary adjacent to
+storage recovery. Its schema admits exactly one SQLite representation for
+each authenticated field, including integer `success` values limited to zero
+or one, and reads validate raw storage classes before projection. Schema-v3
+migration transactionally rebuilds mixed historic data, preserves exact
+RFC3339Nano timestamp material needed to evaluate fractional legacy
+signatures, normalizes finite in-range legacy SQLite REAL timestamps through
+the previously supported truncation rule, and rolls back without partial
+publication, row loss, ordering drift, re-signing, or assurance upgrade when
+any row is malformed.
+
 First-run authentication always writes the canonical `.env` persistence
 artifact before runtime state changes. Root systemd installation may also
 write a service override, but reload, restart, backup, and recovery remain

--- a/frontend-modern/browser-verification.json
+++ b/frontend-modern/browser-verification.json
@@ -1,47 +1,47 @@
 {
   "version": 1,
-  "base_sha": "3adeb77d60620cdcc4c71431685725384bdc562a",
-  "verified_at": "2026-08-12T08:19:01Z",
+  "base_sha": "b8d61b9e1240be042ab86e724e37910dedda5e9d",
+  "verified_at": "2026-08-12T12:32:29Z",
   "result": "passed",
   "changed_paths": [
-    "frontend-modern/src/api/settings.ts",
-    "frontend-modern/src/components/Settings/useInfrastructureSettingsState.ts",
-    "frontend-modern/src/components/Settings/useSystemSettingsState.ts"
+    "frontend-modern/src/components/Settings/AuditLogPanel.tsx",
+    "frontend-modern/src/components/Settings/useAuditLogPanelState.ts",
+    "frontend-modern/src/utils/auditLogPresentation.ts"
   ],
   "content_sha256": {
-    "frontend-modern/src/api/settings.ts": "cb95289d5df7cd9332cc78573a5c6052f8968cc0fbb2d66c15c8ddc49f44ab62",
-    "frontend-modern/src/components/Settings/useInfrastructureSettingsState.ts": "528b32af6b1c777ed87f5dd2d5b15b531f830c520b0f624acfc5a2d75ad3e314",
-    "frontend-modern/src/components/Settings/useSystemSettingsState.ts": "acb66acc4a0254a6816564713f65a1ed5cf723eb526e4960076b4c84335e2c09"
+    "frontend-modern/src/components/Settings/AuditLogPanel.tsx": "4e03c4857c755c96d3672d095ca47485b76d97e9909f64c768d03d9f4e851ae1",
+    "frontend-modern/src/components/Settings/useAuditLogPanelState.ts": "11cd7e750816e8dd937c3ab6885732d6e19ce2bc703459eb15b42303932a3e87",
+    "frontend-modern/src/utils/auditLogPresentation.ts": "20a7770c962309300acc43394e363bb1479a184ceaa1d0726decb8ff41086a6e"
   },
   "routes": [
-    "/settings/system-general"
+    "/settings/security-audit",
+    "/settings/security-audit?verification=compatibility"
   ],
   "viewports": [
     {
       "width": 1280,
-      "height": 720
+      "height": 800
     },
     {
-      "width": 375,
-      "height": 812
+      "width": 390,
+      "height": 844
     }
   ],
   "states": [
-    "Admin session Monitoring Cadence card at the fresh-install Realtime (10s) default",
-    "Admin card after selecting the Low (60s) preset and saving (GET /api/system/settings confirmed pvePollingInterval 60)",
-    "Non-admin session (persisted session cookie whose user no longer matches the configured admin) with GET /api/system/settings returning 403 while GET /api/runtime/display returned pvePollingInterval 60: card showed Current cadence: 60 seconds with Low (60s) pressed instead of the old Realtime fallback",
-    "Admin card after switching to Custom 45s and saving (GET /api/system/settings confirmed 45)",
-    "Non-admin card after reload showing Current cadence: 45 seconds with Custom pressed and 45 in the custom input",
-    "Same non-admin Custom 45s state re-exercised at the 375px mobile viewport",
-    "Admin session reload showing Custom 45s restored through the refactored preset-resolution path"
+    "Synthetic current v3 evidence rendered Strong with green trust styling and a current-verification tooltip",
+    "Synthetic historical v2 evidence rendered Compatibility with amber styling and an explicit lower-assurance tooltip",
+    "Synthetic tampered v3 evidence rendered Invalid with red styling and a verification-failed tooltip",
+    "Unsupported-envelope evidence rendered Unknown distinctly from Invalid",
+    "Evidence with no retained signature rendered Unsigned distinctly from unchecked signed evidence",
+    "Summary totals reported one Strong, Compatibility, Invalid, Unknown, and Unsigned record without combining categories",
+    "The same assurance matrix and responsive table were exercised at 1280x800 and 390x844",
+    "The compatibility verification filter retained only the historical compatibility row at both viewports"
   ],
   "interactions": [
-    "Built the sidecar backend and ran it as a scratch instance; logged in as admin on the pulse-1601-admin Vite frontend",
-    "Selected Low (60s) on the Monitoring Cadence card and saved; verified the effective interval via the settings and runtime-display APIs",
-    "Restarted the backend with a different configured admin username so the persisted browser session became a genuine non-admin session (settings 403, security-status capabilities all false)",
-    "Reloaded /settings/system-general in that non-admin session and confirmed the cadence card rendered the server's real 60s interval from the runtime-display projection",
-    "Logged in as the new admin in a separate cookie jar, set a non-preset Custom 45s cadence, and saved",
-    "Reloaded the non-admin session and confirmed Custom 45s displayed, then repeated the check at the 375px mobile viewport",
-    "Reloaded the admin session to confirm the shared preset-resolution refactor still renders the saved Custom 45s state"
+    "Built and ran the exact candidate backend and Vite frontend with an isolated synthetic data directory and key, then authenticated through the real development login flow",
+    "Intercepted only capability and audit evidence responses with a deterministic five-state synthetic fixture while retaining the production page, routing, state hook, and presentation code",
+    "Loaded /settings/security-audit at desktop and narrow viewports and checked every badge plus all five summary totals",
+    "Hovered Compatibility and Invalid row badges and checked their native tooltip text against the authoritative lower-assurance and failure states",
+    "Navigated to the compatibility-filtered route at both viewports and confirmed the Strong row was excluded while Compatibility remained visible"
   ]
 }

--- a/frontend-modern/public/docs/API.md
+++ b/frontend-modern/public/docs/API.md
@@ -711,7 +711,11 @@ Response:
       "path": "/api/login",
       "success": true,
       "details": "Successful login",
-      "signature": "..."
+      "signature": "v3:...",
+      "signature_version": "v3",
+      "signature_status": "strong",
+      "signature_assurance": "strong",
+      "signature_valid": true
     }
   ],
   "total": 1,
@@ -727,9 +731,30 @@ Response:
 {
   "available": true,
   "verified": true,
-  "message": "Event signature verified"
+  "status": "strong",
+  "version": "v3",
+  "assurance": "strong",
+  "message": "Event signature strongly verified"
 }
 ```
+
+`status` and `assurance` are authoritative. `verified` and per-event
+`signature_valid` remain compatibility fields: both `strong` current evidence
+and `compatibility` historical evidence can have a value of `true`. Clients
+must not turn the boolean alone into a green or current-assurance result.
+
+The complete status set is `strong`, `compatibility`, `invalid`, `unknown`, and
+`unsigned`. Versions are `v3`, `v2`, `legacy`, `unknown`, and `unsigned`.
+Unknown/malformed envelopes do not fall back into historical verification.
+
+### Export and Summary
+
+- `GET /api/audit/export?format=json|csv&verify=true` includes signature
+  version, status, and assurance. The compatibility boolean is also retained.
+- `GET /api/audit/summary` returns separate
+  `strong_signature_count`, `compatibility_signature_count`,
+  `invalid_signature_count`, `unknown_signature_count`, and
+  `unsigned_signature_count` totals.
 
 ### Validate API Token (Admin)
 `POST /api/security/validate-token`

--- a/frontend-modern/public/docs/AUDIT_LOGGING.md
+++ b/frontend-modern/public/docs/AUDIT_LOGGING.md
@@ -34,6 +34,7 @@ Pulse automatically captures the following events:
 | `agent_config_fetch` | Agent configuration retrieval attempts | Agent config fetched successfully |
 
 Each event includes:
+
 - **Timestamp** (UTC)
 - **Event type**
 - **User** who triggered the event
@@ -98,7 +99,7 @@ The export includes all events matching the current filter criteria.
 
 ## Tamper Detection
 
-Every audit event is cryptographically signed at creation time. You can verify that an event has not been modified:
+Current audit events are cryptographically signed at creation time. Verification reports both whether the retained bytes match and what integrity claim that signature format can support:
 
 ```bash
 curl http://localhost:7655/api/audit/6b3c9c3c-9a2f-4b3c-9a3b-3d0e8c5c5d45/verify \
@@ -110,11 +111,33 @@ Response:
 {
   "available": true,
   "verified": true,
-  "message": "Event signature verified"
+  "status": "strong",
+  "version": "v3",
+  "assurance": "strong",
+  "message": "Event signature strongly verified"
 }
 ```
 
-If `verified` is `false`, the event data has been tampered with since it was recorded.
+`status` and `assurance` are authoritative. `verified` is retained for older clients and is `true` for both `strong` and `compatibility`; it must not be used to present those states as equivalent.
+
+| Status | Meaning |
+|--------|---------|
+| `strong` | A valid current `v3` signature with injective field encoding and a version-specific HMAC key domain. |
+| `compatibility` | A valid historical `v2` or unprefixed legacy signature. The bytes match an accepted historical format, but that format does not support the current integrity claim. |
+| `invalid` | A known signature format did not verify. Treat the evidence as failed integrity validation. |
+| `unknown` | The envelope is malformed or unsupported, or verification key material is unavailable. Do not retry it under an older format. |
+| `unsigned` | No signature was retained. |
+
+The list API returns `signature_version`, `signature_status`, and `signature_assurance` on every row. JSON and CSV exports include the version and, with `verify=true`, the status and assurance. Summaries separately count strong, compatibility, invalid, unknown, and unsigned evidence. The UI reserves the green **Strongly verified** state for `strong`; compatibility history is amber and explicitly lower assurance.
+
+### Signature versions and compatibility
+
+- `v3:<64 hex digits>` is the current format. Its authenticated message contains the `v3` domain and envelope, an injective length-prefixed representation of every signed string, the exact persisted Unix-second timestamp and success byte, and the retained historical timestamp-evidence field. Its HMAC-SHA256 key is derived from the instance master audit key under the dedicated `pulse.audit.hmac-key\0v3\0` domain. Removing or changing the envelope cannot move the digest into the accepted `v2` or legacy key domain.
+- `v2:<64 hex digits>` uses injective fields but shares the historical master-key domain, so it is compatibility evidence only.
+- An unprefixed 64-hex signature may match one of three historical delimiter-separated encodings. Those encodings have ambiguous string boundaries, so a match is compatibility evidence only.
+- Any other envelope or malformed MAC is `unknown`. Verification dispatch never falls back from a failed prefixed version into an older representation.
+
+Signatures are opaque versioned strings, not fixed-length bare hex fields. The repository has no supported audit consumer that should assume 64 or 67 characters. Webhook/SIEM clients should retain the signature and the explicit version/assurance fields unchanged and use Pulse's verification endpoint for the authoritative result.
 
 ---
 
@@ -153,9 +176,14 @@ Audit events are stored in a SQLite database in the Pulse data directory:
 - **Multi-tenant:** `{data-dir}/orgs/{org-id}/audit/audit.db`
 
 Data directory locations:
+
 - systemd: `/etc/pulse/`
 - Docker/Kubernetes: `/data/`
 - Development: `tmp/dev-config/`
+
+At startup, Pulse transactionally migrates older audit tables to a strict canonical schema. All signed strings are non-null SQLite `TEXT`, timestamps and success flags are canonical `INTEGER` values, and success is restricted to `0` or `1`. Reads validate raw SQLite storage classes and fail closed on alternate integers, nulls, blobs, reals, or noncanonical timestamp evidence instead of verifying a lossy Go projection.
+
+Historical textual timestamps are normalized for ordering while their canonical RFC3339Nano form is retained separately as signature evidence. This preserves genuine fractional legacy timestamps through migration and restart. Pulse never replaces or re-signs a historical signature. A row that was migrated by an older release after its fractional timestamp material had already been discarded remains `invalid` or otherwise lower assurance; the new migration does not invent evidence or upgrade it. A malformed mixed dataset rolls back as one transaction, leaving the original table and rows intact.
 
 ---
 

--- a/frontend-modern/public/docs/WEBHOOKS.md
+++ b/frontend-modern/public/docs/WEBHOOKS.md
@@ -124,7 +124,24 @@ Pro, legacy Pro+, and Cloud support dedicated audit webhooks for security event 
 2. Add your endpoint URL (e.g., `https://siem.corp.local/ingest/pulse`).
 
 ### Security
-Audit webhooks are dispatched asynchronously. The payload includes a `signature` field which can be verified using the per-instance HMAC key stored (encrypted) at `.audit-signing.key` in the Pulse data directory. There is no `PULSE_AUDIT_SIGNING_KEY` override.
+Audit webhooks are dispatched asynchronously. The envelope contains
+`signature_version`, `signature_status`, and `signature_assurance`; its
+`data.signature` is an opaque versioned value. Pulse verifies each event before
+making an assurance claim. New deliveries use `v3`/`strong`/`strong`. A valid
+historical `v2` or unprefixed signature is labelled `compatibility`, never
+strong; an event delivered without an authoritative verifier is `unknown` with
+`none` assurance.
+
+Use `GET /api/audit/<id>/verify` for the authoritative status. Do not treat a
+successful historical boolean result as current assurance, strip or substitute
+the signature prefix, or retry an unknown version as legacy. Core-managed
+instances keep the per-instance master audit key encrypted at
+`.audit-signing.key`; the encrypted file is not raw HMAC material. Pulse Pro can
+instead supply externally managed key material through
+`PULSE_AUDIT_SIGNING_KEY`; treat that value as a high-entropy secret. Pulse does
+not expose raw key material through this webhook contract. External receivers
+should retain the full payload and its explicit version, status, and assurance
+fields rather than assuming a fixed signature length.
 
 ## 🏢 Provider-hosted MSP webhooks
 

--- a/frontend-modern/src/components/Settings/AuditLogPanel.tsx
+++ b/frontend-modern/src/components/Settings/AuditLogPanel.tsx
@@ -28,6 +28,7 @@ import {
   getAuditEventStatusPresentation,
   getAuditEventTypeBadgeClass,
   getAuditLogFeatureGateCopy,
+  getAuditSignatureTooltip,
   getAuditLogEmptyState,
   getAuditLogLoadingState,
   getAuditVerificationBadgePresentation,
@@ -114,8 +115,11 @@ export default function AuditLogPanel() {
   const auditVerificationOptions = (): FilterSelectOption[] => [
     { value: 'all', label: AUDIT_VERIFICATION_FILTER_ALL_LABEL },
     { value: 'needs', label: AUDIT_VERIFICATION_FILTER_NEEDS_LABEL },
-    { value: 'verified', label: 'Verified' },
-    { value: 'failed', label: 'Failed/Error' },
+    { value: 'strong', label: 'Strong' },
+    { value: 'compatibility', label: 'Compatibility' },
+    { value: 'invalid', label: 'Invalid/Error' },
+    { value: 'unknown', label: 'Unknown/Unavailable' },
+    { value: 'unsigned', label: 'Unsigned' },
   ];
 
   const buildAuditFilters = (): FilterDef[] => [
@@ -342,8 +346,11 @@ export default function AuditLogPanel() {
         <div class="flex flex-wrap items-center gap-3 text-xs text-muted">
           <span>Total: {totalEvents()}</span>
           <span>Signed: {verificationSummary().signed}</span>
-          <span>Verified: {verificationSummary().verified}</span>
-          <span>Failed: {verificationSummary().failed}</span>
+          <span>Strong: {verificationSummary().strong}</span>
+          <span>Compatibility: {verificationSummary().compatibility}</span>
+          <span>Invalid: {verificationSummary().invalid}</span>
+          <span>Unknown: {verificationSummary().unknown}</span>
+          <span>Unsigned: {verificationSummary().unsigned}</span>
           <span>Errors: {verificationSummary().error}</span>
           <span>Unavailable: {verificationSummary().unavailable}</span>
           <span>Unchecked: {verificationSummary().unchecked}</span>
@@ -352,10 +359,13 @@ export default function AuditLogPanel() {
             onMouseEnter={(e) => {
               const rect = e.currentTarget.getBoundingClientRect();
               const content = [
-                'Unsigned: no signature stored for this event',
+                'Strong: current v3 signature verified in its cryptographically separate domain',
+                'Compatibility: a historical v2 or legacy signature matched with lower assurance',
+                'Unsigned: no signature is stored for this event',
+                'Unknown: the envelope is unsupported or the verification key is unavailable',
                 'Unavailable: verification not supported by the logger',
                 'Not checked: signature exists but has not been verified',
-                'Failed: signature mismatch or tampering detected',
+                'Invalid: signature mismatch or tampering detected',
                 'Error: verification request failed',
               ].join('\n');
               showTooltip(content, rect.left + rect.width / 2, rect.top, {
@@ -433,9 +443,6 @@ export default function AuditLogPanel() {
                 key: 'verification',
                 label: 'Verification',
                 render: (event) => {
-                  if (!event.signature) {
-                    return <span class="text-xs">Unsigned</span>;
-                  }
                   const state = verification()[event.id];
                   const isVerifying = verifying()[event.id];
                   const badge = getAuditVerificationBadgePresentation(state);
@@ -447,6 +454,7 @@ export default function AuditLogPanel() {
                         fallback={
                           <span
                             class={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${badge.className}`}
+                            title={getAuditSignatureTooltip(event, state)}
                           >
                             {badge.label}
                           </span>
@@ -456,7 +464,7 @@ export default function AuditLogPanel() {
                       </Show>
                       <button
                         onClick={() => void verifyEvent(event)}
-                        disabled={isVerifying}
+                        disabled={isVerifying || !event.signature}
                         class={AUDIT_VERIFY_ROW_BUTTON_CLASS}
                       >
                         Verify

--- a/frontend-modern/src/components/Settings/__tests__/settingsArchitecture.test.ts
+++ b/frontend-modern/src/components/Settings/__tests__/settingsArchitecture.test.ts
@@ -1148,6 +1148,13 @@ describe('settings architecture guardrails', () => {
     expect(auditLogPresentationSource).toContain(
       "AUDIT_VERIFICATION_FILTER_ALL_LABEL = getAllFilterOptionLabel('verification')",
     );
+    expect(auditLogPanelSource).toContain("{ value: 'strong', label: 'Strong' }");
+    expect(auditLogPanelSource).toContain("{ value: 'compatibility', label: 'Compatibility' }");
+    expect(auditLogPanelSource).toContain("{ value: 'invalid', label: 'Invalid/Error' }");
+    expect(auditLogPanelSource).toContain("{ value: 'unknown', label: 'Unknown/Unavailable' }");
+    expect(auditLogPanelSource).toContain("{ value: 'unsigned', label: 'Unsigned' }");
+    expect(auditLogStateSource).toContain('AUTHORITATIVE_VERIFICATION_STATUSES');
+    expect(auditLogStateSource).not.toContain("status: 'verified'");
   });
 
   it('keeps audit-log fetch errors and page-size normalization on shared owners', () => {

--- a/frontend-modern/src/components/Settings/__tests__/useAuditLogPanelState.branchcov0725am.test.tsx
+++ b/frontend-modern/src/components/Settings/__tests__/useAuditLogPanelState.branchcov0725am.test.tsx
@@ -110,8 +110,12 @@ const unsignedEvent = (id: string): AuditEvent => ({
   details: id,
 });
 
-const auditListResponse = (events: AuditEvent[], total: number = events.length): Response =>
-  new Response(JSON.stringify({ events, total, persistentLogging: false }), {
+const auditListResponse = (
+  events: AuditEvent[],
+  total: number = events.length,
+  persistentLogging = false,
+): Response =>
+  new Response(JSON.stringify({ events, total, persistentLogging }), {
     status: 200,
     headers: JSON_HEADERS,
   });
@@ -378,7 +382,10 @@ describe('useAuditLogPanelState branch coverage', () => {
       const { result, cleanup } = await renderIdle();
       const event = signedEvent('a');
       await result.verifyEvent(event);
-      expect(result.verification()[event.id]).toEqual({ status: 'verified', message: 'matched' });
+      expect(result.verification()[event.id]).toEqual({
+        status: 'compatibility',
+        message: 'matched',
+      });
       expect(result.verifying()[event.id]).toBe(false);
       cleanup();
     });
@@ -408,7 +415,7 @@ describe('useAuditLogPanelState branch coverage', () => {
       const { result, cleanup } = await renderIdle();
       const event = signedEvent('a');
       await result.verifyEvent(event);
-      expect(result.verification()[event.id]).toEqual({ status: 'failed', message: 'mismatch' });
+      expect(result.verification()[event.id]).toEqual({ status: 'invalid', message: 'mismatch' });
       cleanup();
     });
 
@@ -485,6 +492,84 @@ describe('useAuditLogPanelState branch coverage', () => {
       expect(result.resumeCount()).toBe(1);
       cleanup();
     });
+  });
+
+  it('uses authoritative server assurance for totals, filters, and resume decisions', async () => {
+    const events: AuditEvent[] = [
+      {
+        ...signedEvent('strong'),
+        signature_version: 'v3',
+        signature_status: 'strong',
+        signature_assurance: 'strong',
+      },
+      {
+        ...signedEvent('compatibility'),
+        signature_version: 'legacy',
+        signature_status: 'compatibility',
+        signature_assurance: 'compatibility',
+      },
+      {
+        ...signedEvent('invalid'),
+        signature_version: 'v3',
+        signature_status: 'invalid',
+        signature_assurance: 'none',
+      },
+      {
+        ...signedEvent('unknown'),
+        signature_version: 'unknown',
+        signature_status: 'unknown',
+        signature_assurance: 'none',
+      },
+      {
+        ...unsignedEvent('unsigned'),
+        signature_version: 'unsigned',
+        signature_status: 'unsigned',
+        signature_assurance: 'none',
+      },
+    ];
+    vi.mocked(apiFetch).mockResolvedValue(auditListResponse(events));
+
+    const { result, cleanup } = await renderIdle({
+      locationSearch: '?verification=compatibility',
+    });
+    expect(result.verificationSummary()).toMatchObject({
+      total: 5,
+      signed: 4,
+      strong: 1,
+      compatibility: 1,
+      invalid: 1,
+      unknown: 1,
+      unsigned: 1,
+      unchecked: 0,
+    });
+    expect(result.filteredEvents().map((event) => event.id)).toEqual(['compatibility']);
+    expect(result.resumeCount()).toBe(1);
+    expect(result.verification()['compatibility']).toEqual({
+      status: 'compatibility',
+      message: 'Historical signature verified with compatibility assurance only',
+    });
+    cleanup();
+  });
+
+  it('does not re-verify events whose list projection already has an authoritative status', async () => {
+    const event: AuditEvent = {
+      ...signedEvent('projected'),
+      signature_version: 'v3',
+      signature_status: 'strong',
+      signature_assurance: 'strong',
+    };
+    vi.mocked(apiFetch).mockImplementation(async (url: string) => {
+      if (isVerifyCall(url)) {
+        throw new Error('projected event was redundantly verified');
+      }
+      return auditListResponse([event], 1, true);
+    });
+
+    const { result, cleanup } = await renderIdle();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(result.verification()['projected']?.status).toBe('strong');
+    expect(vi.mocked(apiFetch).mock.calls.filter(([url]) => isVerifyCall(url))).toHaveLength(0);
+    cleanup();
   });
 
   describe('verifyAllLabel', () => {

--- a/frontend-modern/src/components/Settings/useAuditLogPanelState.ts
+++ b/frontend-modern/src/components/Settings/useAuditLogPanelState.ts
@@ -13,7 +13,10 @@ import { getUpgradeActionDestination } from '@/stores/licenseCommercial';
 import { presentationPolicyHidesUpgradePrompts } from '@/stores/sessionPresentationPolicy';
 import { getRuntimeCapabilityBlock, loadRuntimeCapabilities } from '@/stores/license';
 import { resolveUpgradeDestination } from '@/utils/upgradeNavigation';
-import { getAuditLogFetchErrorMessage } from '@/utils/auditLogPresentation';
+import {
+  getAuditLogFetchErrorMessage,
+  type AuditVerificationStatus,
+} from '@/utils/auditLogPresentation';
 
 export interface AuditEvent {
   id: string;
@@ -25,6 +28,10 @@ export interface AuditEvent {
   success: boolean;
   details: string;
   signature?: string;
+  signature_version?: 'v3' | 'v2' | 'legacy' | 'unknown' | 'unsigned';
+  signature_status?: 'strong' | 'compatibility' | 'invalid' | 'unknown' | 'unsigned';
+  signature_assurance?: 'strong' | 'compatibility' | 'none';
+  signature_valid?: boolean;
 }
 
 interface AuditResponse {
@@ -36,10 +43,13 @@ interface AuditResponse {
 interface VerifyResponse {
   available: boolean;
   verified?: boolean;
+  status?: 'strong' | 'compatibility' | 'invalid' | 'unknown' | 'unsigned';
+  version?: 'v3' | 'v2' | 'legacy' | 'unknown' | 'unsigned';
+  assurance?: 'strong' | 'compatibility' | 'none';
   message?: string;
 }
 
-type VerificationStatus = 'verified' | 'failed' | 'unavailable' | 'error';
+type VerificationStatus = AuditVerificationStatus;
 
 export type VerificationState = {
   status: VerificationStatus;
@@ -57,9 +67,25 @@ type VerifyAllOptions = {
   limit?: number;
   showToast?: boolean;
   resume?: boolean;
+  uncheckedOnly?: boolean;
 };
 
-const ALLOWED_VERIFICATION_FILTERS = new Set(['all', 'needs', 'verified', 'failed']);
+const ALLOWED_VERIFICATION_FILTERS = new Set([
+  'all',
+  'needs',
+  'strong',
+  'compatibility',
+  'invalid',
+  'unknown',
+  'unsigned',
+]);
+const AUTHORITATIVE_VERIFICATION_STATUSES = new Set<AuditVerificationStatus>([
+  'strong',
+  'compatibility',
+  'invalid',
+  'unknown',
+  'unsigned',
+]);
 const ALLOWED_SUCCESS_FILTERS = new Set(['all', 'success', 'failed']);
 const ALLOWED_EVENT_FILTERS = new Set(['', 'login', 'logout', 'config_change', 'startup']);
 const USER_FILTER_DEBOUNCE_MS = 300;
@@ -254,6 +280,19 @@ export const useAuditLogPanelState = () => {
       }
 
       setEvents(data.events);
+      const projectedVerification: Record<string, VerificationState> = {};
+      for (const event of data.events) {
+        const status = event.signature_status;
+        if (!status || !AUTHORITATIVE_VERIFICATION_STATUSES.has(status)) continue;
+        projectedVerification[event.id] = {
+          status,
+          message:
+            status === 'compatibility'
+              ? 'Historical signature verified with compatibility assurance only'
+              : '',
+        };
+      }
+      setVerification(projectedVerification);
       setIsPersistent(data.persistentLogging);
       setTotalEvents(data.total);
 
@@ -262,7 +301,11 @@ export const useAuditLogPanelState = () => {
         if (verificationLimit <= 0) return;
         setTimeout(() => {
           if (!isMounted() || requestGeneration !== auditRequestGeneration) return;
-          void verifyAllEvents({ limit: verificationLimit, showToast: false });
+          void verifyAllEvents({
+            limit: verificationLimit,
+            showToast: false,
+            uncheckedOnly: true,
+          });
         }, 0);
       }
     } catch (err) {
@@ -316,10 +359,13 @@ export const useAuditLogPanelState = () => {
       let status: VerificationStatus = 'unavailable';
       if (!data.available) {
         status = 'unavailable';
+      } else if (data.status) {
+        status = data.status;
       } else if (data.verified) {
-        status = 'verified';
+        // Old servers cannot establish current strong assurance for this UI.
+        status = 'compatibility';
       } else {
-        status = 'failed';
+        status = 'invalid';
       }
 
       setVerification((prev) => ({
@@ -353,10 +399,13 @@ export const useAuditLogPanelState = () => {
 
     const limit = options?.limit;
     let signedEvents = events().filter((event) => event.signature);
+    if (options?.uncheckedOnly) {
+      signedEvents = signedEvents.filter((event) => !verification()[event.id]);
+    }
     if (options?.resume) {
       signedEvents = signedEvents.filter((event) => {
         const state = verification()[event.id];
-        return !state || state.status === 'failed' || state.status === 'error';
+        return !state || state.status === 'invalid' || state.status === 'error';
       });
     }
     if (limit !== undefined) {
@@ -391,8 +440,10 @@ export const useAuditLogPanelState = () => {
     setVerifyCanceled(false);
 
     if (options?.showToast) {
-      let verified = 0;
-      let failed = 0;
+      let strong = 0;
+      let compatibility = 0;
+      let invalid = 0;
+      let unknown = 0;
       let errors = 0;
       let unavailable = 0;
 
@@ -400,11 +451,17 @@ export const useAuditLogPanelState = () => {
         const state = verification()[event.id];
         if (!state) continue;
         switch (state.status) {
-          case 'verified':
-            verified += 1;
+          case 'strong':
+            strong += 1;
             break;
-          case 'failed':
-            failed += 1;
+          case 'compatibility':
+            compatibility += 1;
+            break;
+          case 'invalid':
+            invalid += 1;
+            break;
+          case 'unknown':
+            unknown += 1;
             break;
           case 'error':
             errors += 1;
@@ -417,13 +474,16 @@ export const useAuditLogPanelState = () => {
         }
       }
 
-      if (failed > 0 || errors > 0) {
+      if (compatibility > 0 || invalid > 0 || unknown > 0 || errors > 0) {
         showWarning(
           'Signature verification completed',
-          `Verified ${verified}, failed ${failed}, errors ${errors}, unavailable ${unavailable}.`,
+          `Strong ${strong}, compatibility ${compatibility}, invalid ${invalid}, unknown ${unknown}, errors ${errors}, unavailable ${unavailable}.`,
         );
       } else {
-        showSuccess('Signature verification completed', `Verified ${verified} events.`);
+        showSuccess(
+          'Signature verification completed',
+          `Strong ${strong}, compatibility ${compatibility}.`,
+        );
       }
     }
   };
@@ -433,13 +493,13 @@ export const useAuditLogPanelState = () => {
     events().some((event) => {
       if (!event.signature) return false;
       const state = verification()[event.id];
-      return !state || state.status === 'failed' || state.status === 'error';
+      return !state || state.status === 'invalid' || state.status === 'error';
     });
   const resumeCount = () =>
     events().filter((event) => {
       if (!event.signature) return false;
       const state = verification()[event.id];
-      return !state || state.status === 'failed' || state.status === 'error';
+      return !state || state.status === 'invalid' || state.status === 'error';
     }).length;
   const verifyAllLabel = () => {
     if (!verifyingAll()) return 'Verify All';
@@ -460,15 +520,21 @@ export const useAuditLogPanelState = () => {
     const summary = {
       total: events().length,
       signed: 0,
-      verified: 0,
-      failed: 0,
+      strong: 0,
+      compatibility: 0,
+      invalid: 0,
+      unknown: 0,
+      unsigned: 0,
       error: 0,
       unavailable: 0,
       unchecked: 0,
     };
 
     for (const event of events()) {
-      if (!event.signature) continue;
+      if (!event.signature) {
+        summary.unsigned += 1;
+        continue;
+      }
       summary.signed += 1;
       const state = verification()[event.id];
       if (!state) {
@@ -476,11 +542,17 @@ export const useAuditLogPanelState = () => {
         continue;
       }
       switch (state.status) {
-        case 'verified':
-          summary.verified += 1;
+        case 'strong':
+          summary.strong += 1;
           break;
-        case 'failed':
-          summary.failed += 1;
+        case 'compatibility':
+          summary.compatibility += 1;
+          break;
+        case 'invalid':
+          summary.invalid += 1;
+          break;
+        case 'unknown':
+          summary.unknown += 1;
           break;
         case 'error':
           summary.error += 1;
@@ -522,13 +594,15 @@ export const useAuditLogPanelState = () => {
     const filter = verificationFilter();
     if (filter === 'all') return events();
     return events().filter((event) => {
-      if (!event.signature) return false;
+      if (!event.signature) return filter === 'unsigned';
       const state = verification()[event.id];
       if (!state) {
         return filter === 'needs';
       }
-      if (filter === 'verified') return state.status === 'verified';
-      if (filter === 'failed') return state.status === 'failed' || state.status === 'error';
+      if (filter === 'strong') return state.status === 'strong';
+      if (filter === 'compatibility') return state.status === 'compatibility';
+      if (filter === 'invalid') return state.status === 'invalid' || state.status === 'error';
+      if (filter === 'unknown') return state.status === 'unknown' || state.status === 'unavailable';
       return false;
     });
   });

--- a/frontend-modern/src/utils/__tests__/auditLogPresentation.branchcov0713.test.ts
+++ b/frontend-modern/src/utils/__tests__/auditLogPresentation.branchcov0713.test.ts
@@ -103,8 +103,8 @@ describe('getAuditVerificationBadgePresentation (branch coverage)', () => {
   it('distinguishes the three outcome colours while sharing one neutral class', () => {
     const notChecked = getAuditVerificationBadgePresentation(undefined);
     const unavailable = getAuditVerificationBadgePresentation({ status: 'unavailable' });
-    const verified = getAuditVerificationBadgePresentation({ status: 'verified' });
-    const failed = getAuditVerificationBadgePresentation({ status: 'failed' });
+    const verified = getAuditVerificationBadgePresentation({ status: 'strong' });
+    const failed = getAuditVerificationBadgePresentation({ status: 'invalid' });
     const errored = getAuditVerificationBadgePresentation({ status: 'error' });
 
     // The verified/failed/error outcomes each carry a distinct colour class.

--- a/frontend-modern/src/utils/__tests__/auditLogPresentation.test.ts
+++ b/frontend-modern/src/utils/__tests__/auditLogPresentation.test.ts
@@ -14,6 +14,7 @@ import {
   getAuditEventTypeBadgeClass,
   getAuditLogFetchErrorMessage,
   getAuditLogFeatureGateCopy,
+  getAuditSignatureTooltip,
   getAuditVerificationBadgePresentation,
 } from '@/utils/auditLogPresentation';
 
@@ -30,14 +31,47 @@ describe('auditLogPresentation', () => {
       label: 'Not checked',
       className: 'bg-surface-alt text-base-content',
     });
-    expect(getAuditVerificationBadgePresentation({ status: 'verified' })).toEqual({
-      label: 'Verified',
+    expect(getAuditVerificationBadgePresentation({ status: 'strong' })).toEqual({
+      label: 'Strong',
       className: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
     });
-    expect(getAuditVerificationBadgePresentation({ status: 'failed' })).toEqual({
-      label: 'Failed',
+    expect(getAuditVerificationBadgePresentation({ status: 'compatibility' })).toEqual({
+      label: 'Compatibility',
+      className: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+    });
+    expect(getAuditVerificationBadgePresentation({ status: 'invalid' })).toEqual({
+      label: 'Invalid',
       className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
     });
+  });
+
+  it('keeps signature tooltips explicit about assurance', () => {
+    expect(
+      getAuditSignatureTooltip(
+        { signature_version: 'v3', signature_assurance: 'strong' },
+        { status: 'strong' },
+      ),
+    ).toBe('Current signature strongly verified');
+    expect(
+      getAuditSignatureTooltip(
+        { signature_version: 'legacy', signature_assurance: 'compatibility' },
+        { status: 'compatibility' },
+      ),
+    ).toBe('Historical signature verified with compatibility assurance only');
+    expect(
+      getAuditSignatureTooltip(
+        { signature_version: 'v3', signature_assurance: 'none' },
+        { status: 'invalid' },
+      ),
+    ).toBe('Signature verification failed');
+    expect(
+      getAuditSignatureTooltip(
+        { signature_version: 'unknown', signature_assurance: 'none' },
+        { status: 'unknown' },
+      ),
+    ).toBe('Signature version is unknown');
+    expect(getAuditSignatureTooltip({}, { status: 'unknown' })).toContain('unknown');
+    expect(getAuditSignatureTooltip({}, undefined)).toContain('not been checked');
   });
 
   it('returns canonical event status icon presentation', () => {

--- a/frontend-modern/src/utils/__tests__/docsLinks.test.ts
+++ b/frontend-modern/src/utils/__tests__/docsLinks.test.ts
@@ -152,6 +152,21 @@ describe('docsLinks', () => {
     expect(importContract).toContain('settings:write');
   });
 
+  it('ships the authoritative audit assurance contract', () => {
+    const apiReference = readFileSync(path.join(repoRoot, 'docs', 'API.md'), 'utf8');
+    const shippedAPIReference = readFileSync(
+      path.join(frontendRoot, 'public', 'docs', 'API.md'),
+      'utf8',
+    );
+
+    expect(shippedAPIReference).toBe(apiReference);
+    expect(apiReference).toContain('`status` and `assurance` are authoritative');
+    expect(apiReference).toContain('`strong`, `compatibility`, `invalid`, `unknown`, and');
+    expect(apiReference).toContain('`unsigned`');
+    expect(apiReference).toContain('Unknown/malformed envelopes do not fall back');
+    expect(apiReference).toContain('`compatibility_signature_count`');
+  });
+
   it('routes runtime docs links through shipped local docs instead of GitHub main', () => {
     expect(apiAccessPanelSource).toContain('API_TOKEN_SCOPES_DOC_URL');
     expect(apiAccessPanelSource).not.toContain(

--- a/frontend-modern/src/utils/auditLogPresentation.ts
+++ b/frontend-modern/src/utils/auditLogPresentation.ts
@@ -3,7 +3,8 @@ import CheckCircle from 'lucide-solid/icons/check-circle';
 import XCircle from 'lucide-solid/icons/x-circle';
 import { getAllFilterOptionLabel } from '@/components/shared/filterOptionPresentation';
 
-export type AuditVerificationStatus = 'verified' | 'failed' | 'unavailable' | 'error';
+export type AuditVerificationStatus =
+  'strong' | 'compatibility' | 'invalid' | 'unknown' | 'unsigned' | 'unavailable' | 'error';
 
 export interface AuditBadgePresentation {
   label: string;
@@ -79,16 +80,28 @@ export function getAuditVerificationBadgePresentation(
   }
 
   switch (state.status) {
-    case 'verified':
+    case 'strong':
       return {
-        label: 'Verified',
+        label: 'Strong',
         className: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
       };
-    case 'failed':
+    case 'compatibility':
       return {
-        label: 'Failed',
+        label: 'Compatibility',
+        className: 'bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200',
+      };
+    case 'invalid':
+      return {
+        label: 'Invalid',
         className: 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200',
       };
+    case 'unknown':
+      return {
+        label: 'Unknown',
+        className: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+      };
+    case 'unsigned':
+      return { label: 'Unsigned', className: 'bg-surface-alt text-base-content' };
     case 'error':
       return {
         label: 'Error',
@@ -97,6 +110,35 @@ export function getAuditVerificationBadgePresentation(
     default:
       return { label: 'Unavailable', className: 'bg-surface-alt text-base-content' };
   }
+}
+
+export function getAuditSignatureTooltip(
+  event: { signature_version?: string; signature_assurance?: string },
+  state?: { status: AuditVerificationStatus; message?: string } | null,
+): string {
+  if (state?.message) return state.message;
+  if (state) {
+    switch (state.status) {
+      case 'strong':
+        return 'Current signature strongly verified';
+      case 'compatibility':
+        return 'Historical signature verified with compatibility assurance only';
+      case 'invalid':
+        return 'Signature verification failed';
+      case 'unknown':
+        return 'Signature version is unknown';
+      case 'unsigned':
+        return 'No signature was retained';
+      case 'error':
+        return 'Signature verification returned an error';
+      default:
+        return 'Signature verification is unavailable';
+    }
+  }
+  if (event.signature_version && event.signature_assurance) {
+    return `Signature ${event.signature_version}; ${event.signature_assurance} assurance`;
+  }
+  return 'Signature assurance has not been checked';
 }
 
 export function getAuditLogLoadingState() {

--- a/internal/api/activity_audit_handlers.go
+++ b/internal/api/activity_audit_handlers.go
@@ -84,7 +84,7 @@ func (h *AuditHandlers) HandleListAuditEvents(w http.ResponseWriter, r *http.Req
 	}
 
 	response := map[string]interface{}{
-		"events":            events,
+		"events":            audit.ProjectEvents(events, logger),
 		"total":             totalCount,
 		"persistentLogging": true,
 	}
@@ -199,9 +199,9 @@ func (h *AuditHandlers) HandleVerifyAuditEvent(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	verifier, ok := logger.(interface {
-		VerifySignature(event audit.Event) bool
-	})
+	_, booleanVerifier := logger.(audit.SignatureVerifier)
+	_, classifiedVerifier := logger.(audit.ClassifiedSignatureVerifier)
+	ok := booleanVerifier || classifiedVerifier
 	if !ok {
 		writeErrorResponse(w, http.StatusNotImplemented, "verify_unavailable", "Signature verification is not available", nil)
 		return
@@ -221,17 +221,16 @@ func (h *AuditHandlers) HandleVerifyAuditEvent(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	verified := verifier.VerifySignature(events[0])
-	message := "Event signature verified"
-	if !verified {
-		message = "Event signature verification failed"
-	}
+	result := audit.ClassifySignature(logger, events[0])
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{
 		"available": true,
-		"verified":  verified,
-		"message":   message,
+		"verified":  result.Verified,
+		"status":    result.Status,
+		"version":   result.Version,
+		"assurance": result.Assurance,
+		"message":   audit.VerificationMessage(result),
 	})
 }
 

--- a/internal/api/audit_assurance_contract_test.go
+++ b/internal/api/audit_assurance_contract_test.go
@@ -1,0 +1,105 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rcourtman/pulse-go-rewrite/pkg/audit"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuditAssuranceContractAcrossHandlers(t *testing.T) {
+	mac := strings.Repeat("a", 64)
+	events := []audit.Event{
+		{ID: "strong", Signature: "v3:" + mac, EventType: "login", Success: true, Timestamp: time.Unix(5, 0).UTC()},
+		{ID: "compatibility", Signature: "v2:" + mac, EventType: "login", Success: true, Timestamp: time.Unix(4, 0).UTC()},
+		{ID: "invalid", Signature: "v3:" + mac, EventType: "login", Timestamp: time.Unix(3, 0).UTC()},
+		{ID: "unknown", Signature: "v9:" + mac, EventType: "login", Timestamp: time.Unix(2, 0).UTC()},
+		{ID: "unsigned", EventType: "login", Timestamp: time.Unix(1, 0).UTC()},
+	}
+	results := map[string]audit.SignatureVerification{
+		"strong":        {Status: audit.VerificationStatusStrong, Version: audit.SignatureVersionV3, Assurance: audit.SignatureAssuranceStrong, Verified: true},
+		"compatibility": {Status: audit.VerificationStatusCompatibility, Version: audit.SignatureVersionV2, Assurance: audit.SignatureAssuranceCompatibility, Verified: true},
+		"invalid":       {Status: audit.VerificationStatusInvalid, Version: audit.SignatureVersionV3, Assurance: audit.SignatureAssuranceNone},
+		"unknown":       {Status: audit.VerificationStatusUnknown, Version: audit.SignatureVersionUnknown, Assurance: audit.SignatureAssuranceNone},
+		"unsigned":      {Status: audit.VerificationStatusUnsigned, Version: audit.SignatureVersionUnsigned, Assurance: audit.SignatureAssuranceNone},
+	}
+	logger := &classifiedTestAuditLogger{
+		testAuditLogger: &testAuditLogger{events: events},
+		results:         results,
+	}
+	setAuditLogger(t, logger)
+	handler := NewAuditHandlers()
+
+	t.Run("verify", func(t *testing.T) {
+		for _, event := range events {
+			event := event
+			t.Run(event.ID, func(t *testing.T) {
+				req := httptest.NewRequest(http.MethodGet, "/api/audit/"+event.ID+"/verify", nil)
+				req.SetPathValue("id", event.ID)
+				rec := httptest.NewRecorder()
+				handler.HandleVerifyAuditEvent(rec, req)
+				assert.Equal(t, http.StatusOK, rec.Code)
+
+				var response verifyResponse
+				assert.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+				want := results[event.ID]
+				assert.Equal(t, want.Status, response.Status)
+				assert.Equal(t, want.Version, response.Version)
+				assert.Equal(t, want.Assurance, response.Assurance)
+				assert.Equal(t, want.Verified, response.Verified)
+			})
+		}
+	})
+
+	t.Run("list", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.HandleListAuditEvents(rec, httptest.NewRequest(http.MethodGet, "/api/audit", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var response struct {
+			Events []audit.EventProjection `json:"events"`
+		}
+		assert.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+		assert.Len(t, response.Events, len(events))
+		for _, event := range response.Events {
+			want := results[event.ID]
+			assert.Equal(t, want.Status, event.SignatureStatus)
+			assert.Equal(t, want.Version, event.SignatureVersion)
+			assert.Equal(t, want.Assurance, event.SignatureAssurance)
+		}
+	})
+
+	t.Run("export", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.HandleExportAuditEvents(rec, httptest.NewRequest(http.MethodGet, "/api/audit/export?format=json&verify=true", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var response struct {
+			Events []audit.ExportEvent `json:"events"`
+		}
+		assert.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+		assert.Len(t, response.Events, len(events))
+		for _, event := range response.Events {
+			want := results[event.ID]
+			assert.Equal(t, want.Status, event.SignatureStatus)
+			assert.Equal(t, want.Version, event.SignatureVersion)
+			assert.Equal(t, want.Assurance, event.SignatureAssurance)
+		}
+	})
+
+	t.Run("summary", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		handler.HandleAuditSummary(rec, httptest.NewRequest(http.MethodGet, "/api/audit/summary", nil))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		var summary audit.ExportSummary
+		assert.NoError(t, json.NewDecoder(rec.Body).Decode(&summary))
+		assert.Equal(t, 1, summary.StrongSigCount)
+		assert.Equal(t, 1, summary.CompatibilitySigCount)
+		assert.Equal(t, 1, summary.InvalidSigCount)
+		assert.Equal(t, 1, summary.UnknownSigCount)
+		assert.Equal(t, 1, summary.UnsignedSigCount)
+	})
+}

--- a/internal/api/audit_handlers_test.go
+++ b/internal/api/audit_handlers_test.go
@@ -17,9 +17,12 @@ import (
 )
 
 type verifyResponse struct {
-	Available bool   `json:"available"`
-	Verified  bool   `json:"verified"`
-	Message   string `json:"message"`
+	Available bool                     `json:"available"`
+	Verified  bool                     `json:"verified"`
+	Status    audit.VerificationStatus `json:"status"`
+	Version   audit.SignatureVersion   `json:"version"`
+	Assurance audit.SignatureAssurance `json:"assurance"`
+	Message   string                   `json:"message"`
 }
 
 type testAuditLogger struct {
@@ -30,6 +33,15 @@ type testAuditLogger struct {
 	countErr     error
 	lastQuery    audit.QueryFilter
 	lastCount    audit.QueryFilter
+}
+
+type classifiedTestAuditLogger struct {
+	*testAuditLogger
+	results map[string]audit.SignatureVerification
+}
+
+func (l *classifiedTestAuditLogger) VerifySignatureResult(event audit.Event) audit.SignatureVerification {
+	return l.results[event.ID]
 }
 
 func (l *testAuditLogger) Record(event audit.Event) error {
@@ -184,7 +196,7 @@ func TestHandleVerifyAuditEvent_NotFound(t *testing.T) {
 
 func TestHandleVerifyAuditEvent_Verified(t *testing.T) {
 	setAuditLogger(t, &testAuditLogger{
-		events:       []audit.Event{{ID: "abc"}},
+		events:       []audit.Event{{ID: "abc", Signature: "v3:" + strings.Repeat("0", 64)}},
 		verifyResult: true,
 	})
 	handler := NewAuditHandlers()
@@ -209,11 +221,14 @@ func TestHandleVerifyAuditEvent_Verified(t *testing.T) {
 	if !resp.Verified {
 		t.Fatalf("expected verified to be true")
 	}
+	assert.Equal(t, audit.VerificationStatusCompatibility, resp.Status)
+	assert.Equal(t, audit.SignatureVersionV3, resp.Version)
+	assert.Equal(t, audit.SignatureAssuranceCompatibility, resp.Assurance)
 }
 
 func TestHandleVerifyAuditEvent_Failed(t *testing.T) {
 	setAuditLogger(t, &testAuditLogger{
-		events:       []audit.Event{{ID: "abc"}},
+		events:       []audit.Event{{ID: "abc", Signature: "v3:" + strings.Repeat("0", 64)}},
 		verifyResult: false,
 	})
 	handler := NewAuditHandlers()
@@ -238,6 +253,9 @@ func TestHandleVerifyAuditEvent_Failed(t *testing.T) {
 	if resp.Verified {
 		t.Fatalf("expected verified to be false")
 	}
+	assert.Equal(t, audit.VerificationStatusInvalid, resp.Status)
+	assert.Equal(t, audit.SignatureVersionV3, resp.Version)
+	assert.Equal(t, audit.SignatureAssuranceNone, resp.Assurance)
 
 	t.Run("Event not found", func(t *testing.T) {
 		setAuditLogger(t, &testAuditLogger{

--- a/pkg/audit/async_logger.go
+++ b/pkg/audit/async_logger.go
@@ -96,13 +96,15 @@ func (l *AsyncLogger) IsPersistentAuditLogger() bool {
 
 // VerifySignature delegates verification to persistent backends.
 func (l *AsyncLogger) VerifySignature(event Event) bool {
+	return l.VerifySignatureResult(event).Verified
+}
+
+// VerifySignatureResult preserves classified assurance through async wrapping.
+func (l *AsyncLogger) VerifySignatureResult(event Event) SignatureVerification {
 	if l == nil {
-		return false
+		return ClassifySignature(nil, event)
 	}
-	verifier, ok := l.backend.(interface {
-		VerifySignature(Event) bool
-	})
-	return ok && verifier.VerifySignature(event)
+	return ClassifySignature(l.backend, event)
 }
 
 // Close drains queued events, stops the worker, and closes the backend logger.

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -21,15 +21,16 @@ import (
 
 // Event represents a single audit log entry.
 type Event struct {
-	ID        string    `json:"id"`
-	Timestamp time.Time `json:"timestamp"`
-	EventType string    `json:"event"` // "login", "logout", "config_change", etc.
-	User      string    `json:"user,omitempty"`
-	IP        string    `json:"ip"`
-	Path      string    `json:"path,omitempty"`
-	Success   bool      `json:"success"`
-	Details   string    `json:"details,omitempty"`
-	Signature string    `json:"signature,omitempty"` // Empty for OSS, HMAC for enterprise
+	ID                 string    `json:"id"`
+	Timestamp          time.Time `json:"timestamp"`
+	EventType          string    `json:"event"` // "login", "logout", "config_change", etc.
+	User               string    `json:"user,omitempty"`
+	IP                 string    `json:"ip"`
+	Path               string    `json:"path,omitempty"`
+	Success            bool      `json:"success"`
+	Details            string    `json:"details,omitempty"`
+	Signature          string    `json:"signature,omitempty"` // Empty for OSS, HMAC for enterprise
+	SignatureTimestamp string    `json:"-"`                   // Retained legacy RFC3339Nano signing material.
 }
 
 // QueryFilter defines filters for querying audit events.

--- a/pkg/audit/export.go
+++ b/pkg/audit/export.go
@@ -26,16 +26,19 @@ type ExportResult struct {
 
 // ExportEvent extends Event with verification status for exports.
 type ExportEvent struct {
-	ID             string    `json:"id"`
-	Timestamp      time.Time `json:"timestamp"`
-	EventType      string    `json:"event_type"`
-	User           string    `json:"user,omitempty"`
-	IP             string    `json:"ip,omitempty"`
-	Path           string    `json:"path,omitempty"`
-	Success        bool      `json:"success"`
-	Details        string    `json:"details,omitempty"`
-	Signature      string    `json:"signature,omitempty"`
-	SignatureValid *bool     `json:"signature_valid,omitempty"`
+	ID                 string             `json:"id"`
+	Timestamp          time.Time          `json:"timestamp"`
+	EventType          string             `json:"event_type"`
+	User               string             `json:"user,omitempty"`
+	IP                 string             `json:"ip,omitempty"`
+	Path               string             `json:"path,omitempty"`
+	Success            bool               `json:"success"`
+	Details            string             `json:"details,omitempty"`
+	Signature          string             `json:"signature,omitempty"`
+	SignatureVersion   SignatureVersion   `json:"signature_version"`
+	SignatureStatus    VerificationStatus `json:"signature_status,omitempty"`
+	SignatureAssurance SignatureAssurance `json:"signature_assurance,omitempty"`
+	SignatureValid     *bool              `json:"signature_valid,omitempty"`
 }
 
 // PersistentLogger defines the interface for loggers that support querying and verification.
@@ -69,20 +72,26 @@ func (e *Exporter) Export(filter QueryFilter, format ExportFormat, includeVerifi
 	exportEvents := make([]ExportEvent, len(events))
 	for i, event := range events {
 		exportEvents[i] = ExportEvent{
-			ID:        event.ID,
-			Timestamp: event.Timestamp,
-			EventType: event.EventType,
-			User:      event.User,
-			IP:        event.IP,
-			Path:      event.Path,
-			Success:   event.Success,
-			Details:   event.Details,
-			Signature: event.Signature,
+			ID:               event.ID,
+			Timestamp:        event.Timestamp,
+			EventType:        event.EventType,
+			User:             event.User,
+			IP:               event.IP,
+			Path:             event.Path,
+			Success:          event.Success,
+			Details:          event.Details,
+			Signature:        event.Signature,
+			SignatureVersion: DetectSignatureVersion(event.Signature),
 		}
 
-		if includeVerification && event.Signature != "" {
-			valid := e.logger.VerifySignature(event)
-			exportEvents[i].SignatureValid = &valid
+		if includeVerification {
+			result := ClassifySignature(e.logger, event)
+			exportEvents[i].SignatureStatus = result.Status
+			exportEvents[i].SignatureAssurance = result.Assurance
+			if result.Status != VerificationStatusUnsigned {
+				valid := result.Verified
+				exportEvents[i].SignatureValid = &valid
+			}
 		}
 	}
 
@@ -105,9 +114,9 @@ func (e *Exporter) exportCSV(events []ExportEvent, timestamp string, includeVeri
 	writer := csv.NewWriter(&buf)
 
 	// Write header
-	header := []string{"ID", "Timestamp", "Event Type", "User", "IP", "Path", "Success", "Details", "Signature"}
+	header := []string{"ID", "Timestamp", "Event Type", "User", "IP", "Path", "Success", "Details", "Signature", "Signature Version"}
 	if includeVerification {
-		header = append(header, "Signature Valid")
+		header = append(header, "Signature Valid", "Signature Status", "Signature Assurance")
 	}
 	if err := writer.Write(header); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
@@ -130,6 +139,7 @@ func (e *Exporter) exportCSV(events []ExportEvent, timestamp string, includeVeri
 			success,
 			event.Details,
 			event.Signature,
+			string(event.SignatureVersion),
 		}
 
 		if includeVerification {
@@ -141,7 +151,7 @@ func (e *Exporter) exportCSV(events []ExportEvent, timestamp string, includeVeri
 					sigValid = "false"
 				}
 			}
-			row = append(row, sigValid)
+			row = append(row, sigValid, string(event.SignatureStatus), string(event.SignatureAssurance))
 		}
 
 		if err := writer.Write(row); err != nil {
@@ -190,14 +200,18 @@ func (e *Exporter) exportJSON(events []ExportEvent, timestamp string) (*ExportRe
 
 // ExportSummary generates a summary of audit activity.
 type ExportSummary struct {
-	TotalEvents     int            `json:"total_events"`
-	SuccessCount    int            `json:"success_count"`
-	FailureCount    int            `json:"failure_count"`
-	EventsByType    map[string]int `json:"events_by_type"`
-	EventsByUser    map[string]int `json:"events_by_user"`
-	StartTime       *time.Time     `json:"start_time,omitempty"`
-	EndTime         *time.Time     `json:"end_time,omitempty"`
-	InvalidSigCount int            `json:"invalid_signature_count,omitempty"`
+	TotalEvents           int            `json:"total_events"`
+	SuccessCount          int            `json:"success_count"`
+	FailureCount          int            `json:"failure_count"`
+	EventsByType          map[string]int `json:"events_by_type"`
+	EventsByUser          map[string]int `json:"events_by_user"`
+	StartTime             *time.Time     `json:"start_time,omitempty"`
+	EndTime               *time.Time     `json:"end_time,omitempty"`
+	StrongSigCount        int            `json:"strong_signature_count"`
+	CompatibilitySigCount int            `json:"compatibility_signature_count"`
+	InvalidSigCount       int            `json:"invalid_signature_count"`
+	UnknownSigCount       int            `json:"unknown_signature_count"`
+	UnsignedSigCount      int            `json:"unsigned_signature_count"`
 }
 
 // GenerateSummary creates a summary of audit events matching the filter.
@@ -242,11 +256,21 @@ func (e *Exporter) GenerateSummary(filter QueryFilter, verifySignatures bool) (*
 			maxTime = &t
 		}
 
-		// Verify signatures if requested
-		if verifySignatures && event.Signature != "" {
-			if !e.logger.VerifySignature(event) {
-				summary.InvalidSigCount++
-			}
+		// Always classify summary evidence so lower-assurance and unsigned rows
+		// cannot disappear into a single invalid count. verifySignatures remains
+		// in the API for request compatibility.
+		_ = verifySignatures
+		switch ClassifySignature(e.logger, event).Status {
+		case VerificationStatusStrong:
+			summary.StrongSigCount++
+		case VerificationStatusCompatibility:
+			summary.CompatibilitySigCount++
+		case VerificationStatusInvalid:
+			summary.InvalidSigCount++
+		case VerificationStatusUnknown:
+			summary.UnknownSigCount++
+		case VerificationStatusUnsigned:
+			summary.UnsignedSigCount++
 		}
 	}
 

--- a/pkg/audit/export_branchcov0724pm_test.go
+++ b/pkg/audit/export_branchcov0724pm_test.go
@@ -44,7 +44,7 @@ func TestBranchcov0724pmExportCSV_EmptyEventsAndVerificationArms(t *testing.T) {
 	if len(records) != 1 {
 		t.Fatalf("want exactly 1 header record, got %d", len(records))
 	}
-	wantHeader := []string{"ID", "Timestamp", "Event Type", "User", "IP", "Path", "Success", "Details", "Signature"}
+	wantHeader := []string{"ID", "Timestamp", "Event Type", "User", "IP", "Path", "Success", "Details", "Signature", "Signature Version"}
 	if len(records[0]) != len(wantHeader) {
 		t.Fatalf("header has %d cols, want %d (%v)", len(records[0]), len(wantHeader), records[0])
 	}
@@ -78,11 +78,11 @@ func TestBranchcov0724pmExportCSV_EmptyEventsAndVerificationArms(t *testing.T) {
 	if len(records) != 4 { // header + 3 rows
 		t.Fatalf("want 4 records, got %d", len(records))
 	}
-	// Header must now carry the appended verification column.
-	if records[0][len(records[0])-1] != "Signature Valid" {
-		t.Fatalf("last header = %q, want %q", records[0][len(records[0])-1], "Signature Valid")
+	// Header carries validity plus authoritative status and assurance columns.
+	if records[0][len(records[0])-3] != "Signature Valid" || records[0][len(records[0])-2] != "Signature Status" || records[0][len(records[0])-1] != "Signature Assurance" {
+		t.Fatalf("verification headers = %v", records[0])
 	}
-	// Per-row verdict column (last column) must reflect each sub-arm exactly.
+	// Per-row validity column must reflect each sub-arm exactly.
 	wantVerdicts := map[string]string{
 		"nil-verdict":   "",
 		"true-verdict":  "true",
@@ -90,7 +90,7 @@ func TestBranchcov0724pmExportCSV_EmptyEventsAndVerificationArms(t *testing.T) {
 	}
 	for _, row := range records[1:] {
 		id := row[0]
-		verdict := row[len(row)-1]
+		verdict := row[len(row)-3]
 		if wantVerdicts[id] != verdict {
 			t.Fatalf("row %q verdict col = %q, want %q", id, verdict, wantVerdicts[id])
 		}

--- a/pkg/audit/export_test.go
+++ b/pkg/audit/export_test.go
@@ -88,7 +88,7 @@ func TestExporterExportAndSummary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("summary error: %v", err)
 	}
-	if summary.TotalEvents != 2 || summary.InvalidSigCount == 0 {
+	if summary.TotalEvents != 2 || summary.UnknownSigCount != 1 || summary.UnsignedSigCount != 1 {
 		t.Fatalf("unexpected summary: %+v", summary)
 	}
 }

--- a/pkg/audit/signer.go
+++ b/pkg/audit/signer.go
@@ -27,7 +27,10 @@ type Signer struct {
 
 const (
 	signatureV2Prefix = "v2:"
+	signatureV3Prefix = "v3:"
 	canonicalV2Domain = "pulse.audit.event\x00v2\x00"
+	canonicalV3Domain = "pulse.audit.event\x00v3\x00"
+	v3KeyDomain       = "pulse.audit.hmac-key\x00v3\x00"
 )
 
 // SignatureVersion identifies the representation authenticated by a signature.
@@ -36,10 +39,57 @@ const (
 type SignatureVersion string
 
 const (
-	SignatureVersionUnknown SignatureVersion = "unknown"
-	SignatureVersionLegacy  SignatureVersion = "legacy"
-	SignatureVersionV2      SignatureVersion = "v2"
+	SignatureVersionUnsigned SignatureVersion = "unsigned"
+	SignatureVersionUnknown  SignatureVersion = "unknown"
+	SignatureVersionLegacy   SignatureVersion = "legacy"
+	SignatureVersionV2       SignatureVersion = "v2"
+	SignatureVersionV3       SignatureVersion = "v3"
 )
+
+// SignatureAssurance describes the integrity claim supported by a successful
+// verification. Historical schemes remain compatibility-only because their
+// signing domain either has ambiguous field boundaries or shares the legacy
+// master-key domain.
+type SignatureAssurance string
+
+const (
+	SignatureAssuranceNone          SignatureAssurance = "none"
+	SignatureAssuranceCompatibility SignatureAssurance = "compatibility"
+	SignatureAssuranceStrong        SignatureAssurance = "strong"
+)
+
+// VerificationStatus is the authoritative signature-verification outcome.
+// Verified remains available as a compatibility projection, but callers must
+// use Status and Assurance when presenting the strength of the evidence.
+type VerificationStatus string
+
+const (
+	VerificationStatusStrong        VerificationStatus = "strong"
+	VerificationStatusCompatibility VerificationStatus = "compatibility"
+	VerificationStatusInvalid       VerificationStatus = "invalid"
+	VerificationStatusUnknown       VerificationStatus = "unknown"
+	VerificationStatusUnsigned      VerificationStatus = "unsigned"
+)
+
+// SignatureVerification carries a verification result without collapsing
+// compatibility evidence into the current strong assurance class.
+type SignatureVerification struct {
+	Status    VerificationStatus `json:"status"`
+	Version   SignatureVersion   `json:"version"`
+	Assurance SignatureAssurance `json:"assurance"`
+	Verified  bool               `json:"verified"`
+}
+
+// SignatureVerifier is the compatibility verification surface implemented by
+// persistent audit loggers.
+type SignatureVerifier interface {
+	VerifySignature(Event) bool
+}
+
+// ClassifiedSignatureVerifier exposes the authoritative verification result.
+type ClassifiedSignatureVerifier interface {
+	VerifySignatureResult(Event) SignatureVerification
+}
 
 // CryptoEncryptor interface for encrypting/decrypting the signing key.
 // This matches the methods from internal/crypto.CryptoManager.
@@ -132,37 +182,53 @@ func loadAuditSigningKey(cryptoMgr CryptoEncryptor, data []byte) ([]byte, bool, 
 	return nil, false, fmt.Errorf("failed to decrypt audit signing key: %w", err)
 }
 
-// Sign computes an HMAC-SHA256 signature over the injective v2 representation.
-// The version prefix is persisted with the hex-encoded MAC so verification can
-// select exactly one representation without downgrade fallback.
+// Sign computes an HMAC-SHA256 signature over the injective v3 representation.
+// v3 derives a version-specific HMAC key from the retained master key and
+// authenticates its version domain. Removing or substituting the envelope
+// therefore cannot move a v3 digest into an accepted historical MAC domain.
 func (s *Signer) Sign(event Event) string {
 	if s.key == nil {
 		return ""
 	}
 
-	return signatureV2Prefix + hex.EncodeToString(s.mac(s.canonicalV2Form(event)))
+	return signatureV3Prefix + hex.EncodeToString(s.v3MAC(s.canonicalV3Form(event)))
 }
 
-// Verify checks if the event's signature matches its content. A true result for
-// SignatureVersionLegacy confirms only a historical delimiter-based MAC; call
-// DetectSignatureVersion when the stronger v2 boundary guarantee matters.
-// Returns false for invalid, unknown, malformed, or disabled signatures.
+// Verify is the compatibility boolean projection of VerifyResult. Both strong
+// and compatibility results return true; callers that display or aggregate
+// assurance must use VerifyResult instead.
 func (s *Signer) Verify(event Event) bool {
-	if s.key == nil || event.Signature == "" {
-		return false
+	return s.VerifyResult(event).Verified
+}
+
+// VerifyResult checks the signature using exactly the representation selected
+// by its envelope and returns the evidence strength explicitly.
+func (s *Signer) VerifyResult(event Event) SignatureVerification {
+	version := DetectSignatureVersion(event.Signature)
+	if version == SignatureVersionUnsigned {
+		return signatureVerification(VerificationStatusUnsigned, version, SignatureAssuranceNone, false)
+	}
+	if s.key == nil {
+		return signatureVerification(VerificationStatusUnknown, version, SignatureAssuranceNone, false)
 	}
 
-	switch DetectSignatureVersion(event.Signature) {
-	case SignatureVersionV2:
-		provided, err := hex.DecodeString(strings.TrimPrefix(event.Signature, signatureV2Prefix))
-		if err != nil || len(provided) != sha256.Size {
-			return false
+	switch version {
+	case SignatureVersionV3:
+		provided, err := decodeEnvelopeMAC(event.Signature, signatureV3Prefix)
+		if err != nil || !hmac.Equal(s.v3MAC(s.canonicalV3Form(event)), provided) {
+			return signatureVerification(VerificationStatusInvalid, version, SignatureAssuranceNone, false)
 		}
-		return hmac.Equal(s.mac(s.canonicalV2Form(event)), provided)
+		return signatureVerification(VerificationStatusStrong, version, SignatureAssuranceStrong, true)
+	case SignatureVersionV2:
+		provided, err := decodeEnvelopeMAC(event.Signature, signatureV2Prefix)
+		if err != nil || !hmac.Equal(s.mac(s.canonicalV2Form(event)), provided) {
+			return signatureVerification(VerificationStatusInvalid, version, SignatureAssuranceNone, false)
+		}
+		return signatureVerification(VerificationStatusCompatibility, version, SignatureAssuranceCompatibility, true)
 	case SignatureVersionLegacy:
 		provided, err := hex.DecodeString(event.Signature)
 		if err != nil || len(provided) != sha256.Size {
-			return false
+			return signatureVerification(VerificationStatusInvalid, version, SignatureAssuranceNone, false)
 		}
 		// These three unversioned encodings were emitted by historical Pulse
 		// releases. They are intentionally confined to the legacy dispatch arm:
@@ -173,19 +239,71 @@ func (s *Signer) Verify(event Event) bool {
 			s.legacyTimeCanonicalForm(event),
 		} {
 			if hmac.Equal(s.mac([]byte(canonical)), provided) {
-				return true
+				return signatureVerification(VerificationStatusCompatibility, version, SignatureAssuranceCompatibility, true)
 			}
 		}
-		return false
+		return signatureVerification(VerificationStatusInvalid, version, SignatureAssuranceNone, false)
 	default:
-		return false
+		return signatureVerification(VerificationStatusUnknown, version, SignatureAssuranceNone, false)
 	}
+}
+
+func signatureVerification(status VerificationStatus, version SignatureVersion, assurance SignatureAssurance, verified bool) SignatureVerification {
+	return SignatureVerification{Status: status, Version: version, Assurance: assurance, Verified: verified}
+}
+
+func decodeEnvelopeMAC(signature, prefix string) ([]byte, error) {
+	provided, err := hex.DecodeString(strings.TrimPrefix(signature, prefix))
+	if err != nil || len(provided) != sha256.Size {
+		return nil, fmt.Errorf("invalid signature MAC")
+	}
+	return provided, nil
+}
+
+// ClassifySignature uses the richer logger contract when available and keeps a
+// conservative compatibility path for third-party Logger implementations that
+// expose only the historical boolean method.
+func ClassifySignature(verifier any, event Event) SignatureVerification {
+	if classified, ok := verifier.(ClassifiedSignatureVerifier); ok {
+		return classified.VerifySignatureResult(event)
+	}
+
+	version := DetectSignatureVersion(event.Signature)
+	if version == SignatureVersionUnsigned {
+		return signatureVerification(VerificationStatusUnsigned, version, SignatureAssuranceNone, false)
+	}
+	// A boolean-only verifier cannot establish the semantics of an unknown
+	// envelope. Never let its result move malformed or unsupported input into
+	// an accepted historical domain.
+	if version == SignatureVersionUnknown {
+		return signatureVerification(VerificationStatusUnknown, version, SignatureAssuranceNone, false)
+	}
+	booleanVerifier, ok := verifier.(SignatureVerifier)
+	if !ok {
+		return signatureVerification(VerificationStatusUnknown, version, SignatureAssuranceNone, false)
+	}
+	if !booleanVerifier.VerifySignature(event) {
+		return signatureVerification(VerificationStatusInvalid, version, SignatureAssuranceNone, false)
+	}
+	// The old boolean contract can prove only that an implementation accepted
+	// the event. It cannot prove that it applied the v3 domain-separated
+	// verifier, so even a v3 envelope remains compatibility assurance here.
+	return signatureVerification(VerificationStatusCompatibility, version, SignatureAssuranceCompatibility, true)
 }
 
 // DetectSignatureVersion classifies only well-formed signature envelopes.
 // Unprefixed 64-digit hexadecimal MACs are historical. Any prefix other than
-// v2, or any malformed/truncated MAC, is unknown and must fail closed.
+// v2/v3, or any malformed/truncated MAC, is unknown and must fail closed.
 func DetectSignatureVersion(signature string) SignatureVersion {
+	if signature == "" {
+		return SignatureVersionUnsigned
+	}
+	if strings.HasPrefix(signature, signatureV3Prefix) {
+		if isSHA256Hex(signature[len(signatureV3Prefix):]) {
+			return SignatureVersionV3
+		}
+		return SignatureVersionUnknown
+	}
 	if strings.HasPrefix(signature, signatureV2Prefix) {
 		if isSHA256Hex(signature[len(signatureV2Prefix):]) {
 			return SignatureVersionV2
@@ -215,6 +333,44 @@ func (s *Signer) mac(message []byte) []byte {
 	return mac.Sum(nil)
 }
 
+func (s *Signer) v3MAC(message []byte) []byte {
+	mac := hmac.New(sha256.New, s.v3Key())
+	_, _ = mac.Write(message)
+	return mac.Sum(nil)
+}
+
+func (s *Signer) v3Key() []byte {
+	mac := hmac.New(sha256.New, s.key)
+	_, _ = mac.Write([]byte(v3KeyDomain))
+	return mac.Sum(nil)
+}
+
+// canonicalV3Form is the current authenticated SQLite tuple. It retains the
+// v2 field ordering and adds the canonical legacy timestamp evidence column.
+// The version domain is inside the MAC as well as being cryptographically
+// separated by v3Key.
+func (s *Signer) canonicalV3Form(event Event) []byte {
+	var canonical bytes.Buffer
+	canonical.WriteString(canonicalV3Domain)
+	writeLengthPrefixedString(&canonical, signatureV3Prefix)
+	writeLengthPrefixedString(&canonical, event.ID)
+
+	writeInt64BigEndian(&canonical, event.Timestamp.Unix())
+
+	writeLengthPrefixedString(&canonical, event.EventType)
+	writeLengthPrefixedString(&canonical, event.User)
+	writeLengthPrefixedString(&canonical, event.IP)
+	writeLengthPrefixedString(&canonical, event.Path)
+	if event.Success {
+		canonical.WriteByte(1)
+	} else {
+		canonical.WriteByte(0)
+	}
+	writeLengthPrefixedString(&canonical, event.Details)
+	writeLengthPrefixedString(&canonical, event.SignatureTimestamp)
+	return canonical.Bytes()
+}
+
 // canonicalV2Form is an injective representation of the exact SQLite tuple:
 // domain || len(ID) || ID || int64 Unix seconds || len(EventType) || EventType
 // || len(User) || User || len(IP) || IP || len(Path) || Path || Success byte
@@ -226,9 +382,7 @@ func (s *Signer) canonicalV2Form(event Event) []byte {
 	canonical.WriteString(canonicalV2Domain)
 	writeLengthPrefixedString(&canonical, event.ID)
 
-	var timestamp [8]byte
-	binary.BigEndian.PutUint64(timestamp[:], uint64(event.Timestamp.Unix()))
-	canonical.Write(timestamp[:])
+	writeInt64BigEndian(&canonical, event.Timestamp.Unix())
 
 	writeLengthPrefixedString(&canonical, event.EventType)
 	writeLengthPrefixedString(&canonical, event.User)
@@ -248,6 +402,15 @@ func writeLengthPrefixedString(dst *bytes.Buffer, value string) {
 	binary.BigEndian.PutUint64(length[:], uint64(len(value)))
 	dst.Write(length[:])
 	dst.WriteString(value)
+}
+
+func writeInt64BigEndian(dst *bytes.Buffer, value int64) {
+	// bytes.Buffer writes cannot fail. binary.Write preserves the exact two's
+	// complement big-endian representation used by the previous uint64 cast,
+	// without relying on a signed-to-unsigned conversion.
+	if err := binary.Write(dst, binary.BigEndian, value); err != nil {
+		panic("audit: encode int64 into bytes.Buffer: " + err.Error())
+	}
 }
 
 func (s *Signer) signCanonical(canonical string) string {
@@ -284,8 +447,12 @@ func (s *Signer) legacyUnixCanonicalForm(event Event) string {
 }
 
 func (s *Signer) legacyTimeCanonicalForm(event Event) string {
+	timestamp := event.SignatureTimestamp
+	if timestamp == "" {
+		timestamp = event.Timestamp.UTC().Format(time.RFC3339Nano)
+	}
 	return event.ID + "|" +
-		event.Timestamp.UTC().Format(time.RFC3339Nano) + "|" +
+		timestamp + "|" +
 		event.EventType + "|" +
 		event.User + "|" +
 		event.IP + "|" +

--- a/pkg/audit/signer_security_test.go
+++ b/pkg/audit/signer_security_test.go
@@ -1,10 +1,17 @@
 package audit
 
 import (
+	"encoding/hex"
 	"strings"
 	"testing"
 	"time"
 )
+
+type booleanOnlySignatureVerifier bool
+
+func (v booleanOnlySignatureVerifier) VerifySignature(Event) bool {
+	return bool(v)
+}
 
 func securityTestSigner(t *testing.T) *Signer {
 	t.Helper()
@@ -28,7 +35,7 @@ func securityTestEvent() Event {
 	}
 }
 
-func TestSignerV2RejectsEquivalentLegacyBoundaryShifts(t *testing.T) {
+func TestSignerV3RejectsEquivalentLegacyBoundaryShifts(t *testing.T) {
 	signer := securityTestSigner(t)
 
 	tests := []struct {
@@ -69,17 +76,17 @@ func TestSignerV2RejectsEquivalentLegacyBoundaryShifts(t *testing.T) {
 			}
 			original.Signature = signer.Sign(original)
 			if original.Signature == signer.Sign(forged) {
-				t.Fatal("v2 signatures collided for distinct tuples")
+				t.Fatal("v3 signatures collided for distinct tuples")
 			}
 			forged.Signature = original.Signature
 			if signer.Verify(forged) {
-				t.Fatal("v2 signature verified after a boundary shift")
+				t.Fatal("v3 signature verified after a boundary shift")
 			}
 		})
 	}
 }
 
-func TestSignerV2AuthenticatesEveryPersistedField(t *testing.T) {
+func TestSignerV3AuthenticatesEveryPersistedField(t *testing.T) {
 	signer := securityTestSigner(t)
 	original := securityTestEvent()
 	original.Signature = signer.Sign(original)
@@ -96,6 +103,7 @@ func TestSignerV2AuthenticatesEveryPersistedField(t *testing.T) {
 		{name: "path", mutate: func(e *Event) { e.Path += "-tampered" }},
 		{name: "success", mutate: func(e *Event) { e.Success = !e.Success }},
 		{name: "details", mutate: func(e *Event) { e.Details += "-tampered" }},
+		{name: "signature timestamp", mutate: func(e *Event) { e.SignatureTimestamp = "2024-09-05T20:59:15Z" }},
 		{name: "field order", mutate: func(e *Event) { e.EventType, e.User = e.User, e.EventType }},
 	}
 
@@ -110,7 +118,7 @@ func TestSignerV2AuthenticatesEveryPersistedField(t *testing.T) {
 	}
 }
 
-func TestSignerV2PreservesArbitraryStringContent(t *testing.T) {
+func TestSignerV3PreservesArbitraryStringContent(t *testing.T) {
 	signer := securityTestSigner(t)
 	tests := []struct {
 		name  string
@@ -129,11 +137,11 @@ func TestSignerV2PreservesArbitraryStringContent(t *testing.T) {
 			event.User = tt.value
 			event.Details = tt.value
 			event.Signature = signer.Sign(event)
-			if DetectSignatureVersion(event.Signature) != SignatureVersionV2 {
-				t.Fatalf("signature version = %q, want v2", DetectSignatureVersion(event.Signature))
+			if DetectSignatureVersion(event.Signature) != SignatureVersionV3 {
+				t.Fatalf("signature version = %q, want v3", DetectSignatureVersion(event.Signature))
 			}
 			if !signer.Verify(event) {
-				t.Fatal("valid v2 signature did not verify")
+				t.Fatal("valid v3 signature did not verify")
 			}
 			tampered := event
 			tampered.Details += "x"
@@ -144,7 +152,7 @@ func TestSignerV2PreservesArbitraryStringContent(t *testing.T) {
 	}
 }
 
-func TestSignerV2CanonicalRepresentationFixture(t *testing.T) {
+func TestSignerV3CanonicalRepresentationFixture(t *testing.T) {
 	signer := securityTestSigner(t)
 	event := Event{
 		ID:        "id|1",
@@ -156,7 +164,8 @@ func TestSignerV2CanonicalRepresentationFixture(t *testing.T) {
 		Success:   true,
 		Details:   "done|ok",
 	}
-	want := "pulse.audit.event\x00v2\x00" +
+	want := "pulse.audit.event\x00v3\x00" +
+		"\x00\x00\x00\x00\x00\x00\x00\x03v3:" +
 		"\x00\x00\x00\x00\x00\x00\x00\x04id|1" +
 		"\xff\xff\xff\xff\xff\xff\xff\xff" +
 		"\x00\x00\x00\x00\x00\x00\x00\x06監査" +
@@ -164,16 +173,18 @@ func TestSignerV2CanonicalRepresentationFixture(t *testing.T) {
 		"\x00\x00\x00\x00\x00\x00\x00\x01\x00" +
 		"\x00\x00\x00\x00\x00\x00\x00\x01\n" +
 		"\x01" +
-		"\x00\x00\x00\x00\x00\x00\x00\x07done|ok"
-	if got := string(signer.canonicalV2Form(event)); got != want {
-		t.Fatalf("canonical v2 bytes changed:\n got %x\nwant %x", got, want)
+		"\x00\x00\x00\x00\x00\x00\x00\x07done|ok" +
+		"\x00\x00\x00\x00\x00\x00\x00\x00"
+	if got := string(signer.canonicalV3Form(event)); got != want {
+		t.Fatalf("canonical v3 bytes changed:\n got %x\nwant %x", got, want)
 	}
 }
 
 func TestSignerVersionDispatchFailsClosedWithoutDowngrade(t *testing.T) {
 	signer := securityTestSigner(t)
 	event := securityTestEvent()
-	v2Signature := signer.Sign(event)
+	v3Signature := signer.Sign(event)
+	v2Signature := signatureV2Prefix + hex.EncodeToString(signer.mac(signer.canonicalV2Form(event)))
 	legacySignature := signer.signCanonical(signer.legacyZeroOneCanonicalForm(event))
 
 	for _, signature := range []string{
@@ -181,7 +192,7 @@ func TestSignerVersionDispatchFailsClosedWithoutDowngrade(t *testing.T) {
 		"v2:not-hex",
 		"v2:" + strings.Repeat("0", 62),
 		"v2:" + strings.Repeat("0", 66),
-		"v3:" + strings.TrimPrefix(v2Signature, signatureV2Prefix),
+		"v4:" + strings.TrimPrefix(v3Signature, signatureV3Prefix),
 		"unknown:" + strings.TrimPrefix(v2Signature, signatureV2Prefix),
 		strings.TrimPrefix(v2Signature, signatureV2Prefix),
 		"v2:" + legacySignature,
@@ -196,14 +207,95 @@ func TestSignerVersionDispatchFailsClosedWithoutDowngrade(t *testing.T) {
 		})
 	}
 
+	if DetectSignatureVersion(v3Signature) != SignatureVersionV3 {
+		t.Fatal("valid v3 signature was not identified")
+	}
 	if DetectSignatureVersion(v2Signature) != SignatureVersionV2 {
 		t.Fatal("valid v2 signature was not identified")
 	}
 	if DetectSignatureVersion(legacySignature) != SignatureVersionLegacy {
 		t.Fatal("valid legacy envelope was not identified")
 	}
-	if DetectSignatureVersion("v3:"+strings.TrimPrefix(v2Signature, signatureV2Prefix)) != SignatureVersionUnknown {
+	if DetectSignatureVersion("v4:"+strings.TrimPrefix(v3Signature, signatureV3Prefix)) != SignatureVersionUnknown {
 		t.Fatal("unknown version did not fail closed")
+	}
+}
+
+func TestSignerV3KeyDomainRejectsHistoricalCrossEventPrefixStripping(t *testing.T) {
+	signer := securityTestSigner(t)
+	current := securityTestEvent()
+	const legacySuffix = "|0|||||0|"
+	current.Details = legacySuffix
+
+	// Retain the exact historic reproduction: the v2 canonical bytes can be
+	// reinterpreted as the delimiter-based canonical form for a distinct event.
+	v2Message := signer.canonicalV2Form(current)
+	legacy := Event{
+		ID:        string(v2Message[:len(v2Message)-len(legacySuffix)]),
+		Timestamp: time.Unix(0, 0).UTC(),
+	}
+	if got := signer.legacyZeroOneCanonicalForm(legacy); got != string(v2Message) {
+		t.Fatalf("historic cross-event fixture lost byte equality:\n got %x\nwant %x", got, v2Message)
+	}
+	legacy.Signature = hex.EncodeToString(signer.mac(v2Message))
+	if !signer.Verify(legacy) {
+		t.Fatal("fixture no longer reproduces the accepted historical v2-to-legacy conversion")
+	}
+
+	// The current digest uses both an authenticated v3 message and a derived
+	// key. Removing its envelope cannot verify in the master-key legacy domain.
+	current.Signature = signer.Sign(current)
+	legacy.Signature = strings.TrimPrefix(current.Signature, signatureV3Prefix)
+	if signer.Verify(legacy) {
+		t.Fatal("stripped v3 digest verified for a distinct legacy event")
+	}
+	if h := hex.EncodeToString(signer.mac(signer.canonicalV3Form(current))); h == legacy.Signature {
+		t.Fatal("v3 unexpectedly reused the historical master-key MAC")
+	}
+}
+
+func TestSignerVerificationAssuranceMatrix(t *testing.T) {
+	signer := securityTestSigner(t)
+	event := securityTestEvent()
+
+	event.Signature = signer.Sign(event)
+	if got := signer.VerifyResult(event); got.Status != VerificationStatusStrong || got.Assurance != SignatureAssuranceStrong || !got.Verified {
+		t.Fatalf("v3 result = %+v", got)
+	}
+
+	event.Signature = signatureV2Prefix + hex.EncodeToString(signer.mac(signer.canonicalV2Form(event)))
+	if got := signer.VerifyResult(event); got.Status != VerificationStatusCompatibility || got.Assurance != SignatureAssuranceCompatibility || !got.Verified {
+		t.Fatalf("v2 result = %+v", got)
+	}
+
+	event.Signature = signer.signCanonical(signer.legacyZeroOneCanonicalForm(event))
+	if got := signer.VerifyResult(event); got.Status != VerificationStatusCompatibility || got.Assurance != SignatureAssuranceCompatibility || !got.Verified {
+		t.Fatalf("legacy result = %+v", got)
+	}
+
+	event.Signature = "v9:" + strings.Repeat("0", 64)
+	if got := signer.VerifyResult(event); got.Status != VerificationStatusUnknown || got.Verified {
+		t.Fatalf("unknown result = %+v", got)
+	}
+
+	event.Signature = ""
+	if got := signer.VerifyResult(event); got.Status != VerificationStatusUnsigned || got.Version != SignatureVersionUnsigned || got.Verified {
+		t.Fatalf("unsigned result = %+v", got)
+	}
+}
+
+func TestClassifySignatureBooleanFallbackCannotClaimStrongOrAcceptUnknown(t *testing.T) {
+	signer := securityTestSigner(t)
+	event := securityTestEvent()
+	event.Signature = signer.Sign(event)
+
+	if got := ClassifySignature(booleanOnlySignatureVerifier(true), event); got.Status != VerificationStatusCompatibility || got.Assurance != SignatureAssuranceCompatibility || !got.Verified {
+		t.Fatalf("boolean-only v3 result = %+v", got)
+	}
+
+	event.Signature = "v9:" + strings.Repeat("0", 64)
+	if got := ClassifySignature(booleanOnlySignatureVerifier(true), event); got.Status != VerificationStatusUnknown || got.Assurance != SignatureAssuranceNone || got.Verified {
+		t.Fatalf("boolean-only unknown result = %+v", got)
 	}
 }
 

--- a/pkg/audit/signer_test.go
+++ b/pkg/audit/signer_test.go
@@ -219,9 +219,9 @@ func TestSignerSign(t *testing.T) {
 
 	sig := signer.Sign(event)
 
-	// The envelope identifies v2 and carries a 64-character SHA-256 MAC.
-	if len(sig) != len("v2:")+64 || !strings.HasPrefix(sig, "v2:") {
-		t.Errorf("Expected v2 signature envelope, got %q", sig)
+	// The envelope identifies v3 and carries a 64-character SHA-256 MAC.
+	if len(sig) != len("v3:")+64 || !strings.HasPrefix(sig, "v3:") {
+		t.Errorf("Expected v3 signature envelope, got %q", sig)
 	}
 
 	// Same event should produce same signature

--- a/pkg/audit/sqlite_integrity_test.go
+++ b/pkg/audit/sqlite_integrity_test.go
@@ -1,0 +1,317 @@
+package audit
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func legacyFixtureEvent(id string, timestamp time.Time, user string) Event {
+	return Event{
+		ID:        id,
+		Timestamp: timestamp,
+		EventType: "startup",
+		User:      user,
+		IP:        "127.0.0.1",
+		Path:      "/api/audit",
+		Success:   true,
+		Details:   "fixture",
+	}
+}
+
+func TestSQLiteSignatureCompatibilityMatrixPreservesFractionalEvidence(t *testing.T) {
+	dataDir := t.TempDir()
+	key := []byte("0123456789abcdef0123456789abcdef")
+	signer, err := NewSignerWithKey(key)
+	if err != nil {
+		t.Fatalf("NewSignerWithKey: %v", err)
+	}
+	base := time.Date(2025, 7, 8, 9, 10, 11, 987_654_321, time.UTC)
+
+	fractional := legacyFixtureEvent("legacy-fractional", base, "fractional")
+	fractional.Signature = signer.signCanonical(signer.legacyTimeCanonicalForm(fractional))
+	v2 := legacyFixtureEvent("v2", base.Add(time.Second).Truncate(time.Second), "v2")
+	v2.Signature = signatureV2Prefix + hex.EncodeToString(signer.mac(signer.canonicalV2Form(v2)))
+	zeroOne := legacyFixtureEvent("legacy-zero-one", base.Add(2*time.Second).Truncate(time.Second), "zero-one")
+	zeroOne.Signature = signer.signCanonical(signer.legacyZeroOneCanonicalForm(zeroOne))
+	unix := legacyFixtureEvent("legacy-unix", base.Add(3*time.Second).Truncate(time.Second), "unix")
+	unix.Signature = signer.signCanonical(signer.legacyUnixCanonicalForm(unix))
+	realTimestamp := legacyFixtureEvent("legacy-real", base.Add(4*time.Second).Truncate(time.Second), "real")
+	realTimestamp.Signature = signer.signCanonical(signer.legacyUnixCanonicalForm(realTimestamp))
+	invalid := legacyFixtureEvent("invalid", base.Add(5*time.Second).Truncate(time.Second), "invalid")
+	invalid.Signature = strings.Repeat("0", 64)
+	unknown := legacyFixtureEvent("unknown", base.Add(6*time.Second).Truncate(time.Second), "unknown")
+	unknown.Signature = "v9:" + strings.Repeat("0", 64)
+	unsigned := legacyFixtureEvent("unsigned", base.Add(7*time.Second).Truncate(time.Second), "unsigned")
+
+	createLegacyAuditFixture(t, dataDir, []legacyAuditFixtureRow{
+		{id: fractional.ID, timestamp: fractional.Timestamp, user: fractional.User, signature: fractional.Signature},
+		{id: v2.ID, timestamp: v2.Timestamp.Unix(), user: v2.User, signature: v2.Signature},
+		{id: zeroOne.ID, timestamp: zeroOne.Timestamp.Unix(), user: zeroOne.User, signature: zeroOne.Signature},
+		{id: unix.ID, timestamp: unix.Timestamp.Unix(), user: unix.User, signature: unix.Signature},
+		{id: realTimestamp.ID, timestamp: float64(realTimestamp.Timestamp.Unix()), user: realTimestamp.User, signature: realTimestamp.Signature},
+		{id: invalid.ID, timestamp: invalid.Timestamp.Unix(), user: invalid.User, signature: invalid.Signature},
+		{id: unknown.ID, timestamp: unknown.Timestamp.Unix(), user: unknown.User, signature: unknown.Signature},
+		{id: unsigned.ID, timestamp: unsigned.Timestamp.Unix(), user: unsigned.User, signature: nil},
+	})
+
+	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{
+		DataDir:             dataDir,
+		SigningKey:          key,
+		RetentionDays:       0,
+		RetentionConfigured: true,
+	})
+	if err != nil {
+		t.Fatalf("migrate logger: %v", err)
+	}
+	current := Event{ID: "current", Timestamp: base.Add(8 * time.Second), EventType: "startup", Success: true, Details: "fixture"}
+	if err := logger.Record(current); err != nil {
+		t.Fatalf("Record current: %v", err)
+	}
+	if err := logger.Close(); err != nil {
+		t.Fatalf("close migrated logger: %v", err)
+	}
+
+	restarted, err := NewSQLiteLogger(SQLiteLoggerConfig{
+		DataDir:             dataDir,
+		SigningKey:          key,
+		RetentionDays:       0,
+		RetentionConfigured: true,
+	})
+	if err != nil {
+		t.Fatalf("restart logger: %v", err)
+	}
+	defer restarted.Close()
+
+	events, err := restarted.Query(QueryFilter{})
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(events) != 9 {
+		t.Fatalf("events = %d, want 9", len(events))
+	}
+	byID := make(map[string]Event, len(events))
+	for _, event := range events {
+		byID[event.ID] = event
+	}
+	if got := byID[fractional.ID].SignatureTimestamp; got != base.Format(time.RFC3339Nano) {
+		t.Fatalf("fractional signature timestamp = %q, want %q", got, base.Format(time.RFC3339Nano))
+	}
+
+	expected := map[string]VerificationStatus{
+		"current":        VerificationStatusStrong,
+		fractional.ID:    VerificationStatusCompatibility,
+		v2.ID:            VerificationStatusCompatibility,
+		zeroOne.ID:       VerificationStatusCompatibility,
+		unix.ID:          VerificationStatusCompatibility,
+		realTimestamp.ID: VerificationStatusCompatibility,
+		invalid.ID:       VerificationStatusInvalid,
+		unknown.ID:       VerificationStatusUnknown,
+		unsigned.ID:      VerificationStatusUnsigned,
+	}
+	for id, status := range expected {
+		if got := restarted.VerifySignatureResult(byID[id]); got.Status != status {
+			t.Errorf("%s status = %q, want %q (%+v)", id, got.Status, status, got)
+		}
+	}
+
+	summary, err := NewExporter(restarted).GenerateSummary(QueryFilter{}, true)
+	if err != nil {
+		t.Fatalf("GenerateSummary: %v", err)
+	}
+	if summary.StrongSigCount != 1 || summary.CompatibilitySigCount != 5 || summary.InvalidSigCount != 1 || summary.UnknownSigCount != 1 || summary.UnsignedSigCount != 1 {
+		t.Fatalf("summary assurance counts = %+v", summary)
+	}
+}
+
+func TestSQLiteCanonicalStorageAndRawMutationFailClosed(t *testing.T) {
+	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{
+		DataDir:             t.TempDir(),
+		SigningKey:          []byte("0123456789abcdef0123456789abcdef"),
+		RetentionDays:       0,
+		RetentionConfigured: true,
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteLogger: %v", err)
+	}
+	defer logger.Close()
+	event := Event{ID: "canonical", Timestamp: time.Unix(1_750_000_000, 0), EventType: "test", User: "operator", Success: false}
+	if err := logger.Record(event); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	var storageTypes [10]string
+	if err := logger.db.QueryRow(`SELECT typeof(id), typeof(timestamp), typeof(event_type), typeof(user), typeof(ip), typeof(path), typeof(success), typeof(details), typeof(signature), typeof(signature_timestamp) FROM audit_events WHERE id = ?`, event.ID).Scan(
+		&storageTypes[0], &storageTypes[1], &storageTypes[2], &storageTypes[3], &storageTypes[4],
+		&storageTypes[5], &storageTypes[6], &storageTypes[7], &storageTypes[8], &storageTypes[9],
+	); err != nil {
+		t.Fatalf("read storage classes: %v", err)
+	}
+	for i, got := range storageTypes {
+		want := "text"
+		if i == 1 || i == 6 {
+			want = "integer"
+		}
+		if got != want {
+			t.Fatalf("storage type %d = %q, want %q", i, got, want)
+		}
+	}
+
+	for _, mutation := range []string{
+		`UPDATE audit_events SET success = 2 WHERE id = 'canonical'`,
+		`UPDATE audit_events SET user = NULL WHERE id = 'canonical'`,
+		`UPDATE audit_events SET ip = x'00' WHERE id = 'canonical'`,
+		`UPDATE audit_events SET timestamp = 1.5 WHERE id = 'canonical'`,
+	} {
+		if _, err := logger.db.Exec(mutation); err == nil {
+			t.Fatalf("noncanonical mutation succeeded: %s", mutation)
+		}
+	}
+
+	// SQLite losslessly coerces an integer into canonical TEXT storage. That is
+	// still a semantic mutation and must invalidate, rather than preserve, the
+	// signature through a lossy Go projection.
+	if _, err := logger.db.Exec(`UPDATE audit_events SET user = 42 WHERE id = ?`, event.ID); err != nil {
+		t.Fatalf("coerced text mutation: %v", err)
+	}
+	mutated, err := logger.Query(QueryFilter{ID: event.ID})
+	if err != nil || len(mutated) != 1 {
+		t.Fatalf("query coerced mutation: %v / %d", err, len(mutated))
+	}
+	if result := logger.VerifySignatureResult(mutated[0]); result.Status != VerificationStatusInvalid {
+		t.Fatalf("coerced mutation result = %+v", result)
+	}
+	if _, err := logger.db.Exec(`UPDATE audit_events SET user = 'operator' WHERE id = ?`, event.ID); err != nil {
+		t.Fatalf("restore user: %v", err)
+	}
+
+	// Even if a privileged connection disables CHECK constraints, decoding the
+	// raw storage class/value rejects the historic success=2 projection flaw.
+	if _, err := logger.db.Exec(`PRAGMA ignore_check_constraints = ON`); err != nil {
+		t.Fatalf("enable constraint bypass: %v", err)
+	}
+	if _, err := logger.db.Exec(`UPDATE audit_events SET success = 2 WHERE id = ?`, event.ID); err != nil {
+		t.Fatalf("inject noncanonical success: %v", err)
+	}
+	if _, err := logger.Query(QueryFilter{ID: event.ID}); err == nil {
+		t.Fatal("query accepted noncanonical success=2")
+	}
+	if _, err := logger.db.Exec(`UPDATE audit_events SET success = 0, signature_timestamp = '2025-06-15T15:06:40+00:00' WHERE id = ?`, event.ID); err != nil {
+		t.Fatalf("inject alternate timestamp encoding: %v", err)
+	}
+	if _, err := logger.Query(QueryFilter{ID: event.ID}); err == nil {
+		t.Fatal("query accepted alternate signature timestamp encoding")
+	}
+}
+
+func TestSQLiteCanonicalStoragePreservesEmptySignedStrings(t *testing.T) {
+	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{
+		DataDir:             t.TempDir(),
+		SigningKey:          []byte("0123456789abcdef0123456789abcdef"),
+		RetentionDays:       0,
+		RetentionConfigured: true,
+	})
+	if err != nil {
+		t.Fatalf("NewSQLiteLogger: %v", err)
+	}
+	defer logger.Close()
+
+	// Logger.Record has historically accepted empty ID and event type strings.
+	// They remain one canonical TEXT representation even though NULL and other
+	// SQLite storage classes fail closed.
+	event := Event{Timestamp: time.Unix(1_750_000_000, 0), Success: true}
+	if err := logger.Record(event); err != nil {
+		t.Fatalf("Record empty signed strings: %v", err)
+	}
+	events, err := logger.Query(QueryFilter{Limit: 1})
+	if err != nil || len(events) != 1 {
+		t.Fatalf("Query empty signed strings: %v / %d", err, len(events))
+	}
+	if events[0].ID != "" || events[0].EventType != "" {
+		t.Fatalf("empty signed strings changed: %+v", events[0])
+	}
+	if result := logger.VerifySignatureResult(events[0]); result.Status != VerificationStatusStrong {
+		t.Fatalf("empty signed string assurance = %+v", result)
+	}
+}
+
+func TestSQLiteMigrationInjectedInterruptionRollsBackExactly(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := createLegacyAuditFixture(t, dataDir, []legacyAuditFixtureRow{
+		{id: "one", timestamp: "2025-01-01T00:00:00.123456789Z", user: nil, signature: nil},
+		{id: "two", timestamp: int64(1_735_689_601), user: "operator", signature: ""},
+	})
+
+	previousHook := auditMigrationBeforeInsert
+	inserted := 0
+	auditMigrationBeforeInsert = func(canonicalAuditRow) error {
+		inserted++
+		if inserted == 2 {
+			return errors.New("synthetic migration interruption")
+		}
+		return nil
+	}
+	t.Cleanup(func() { auditMigrationBeforeInsert = previousHook })
+
+	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{DataDir: dataDir, SigningKey: []byte("0123456789abcdef0123456789abcdef")})
+	if logger != nil || err == nil || !strings.Contains(err.Error(), "synthetic migration interruption") {
+		t.Fatalf("interrupted migration = logger %v, err %v", logger, err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("reopen original: %v", err)
+	}
+	defer db.Close()
+	var columnType string
+	if err := db.QueryRow(`SELECT type FROM pragma_table_info('audit_events') WHERE name = 'timestamp'`).Scan(&columnType); err != nil {
+		t.Fatalf("read original schema: %v", err)
+	}
+	if columnType != "DATETIME" {
+		t.Fatalf("partial schema publication: timestamp type %q", columnType)
+	}
+	var count, scratch int
+	if err := db.QueryRow(`SELECT COUNT(*) FROM audit_events`).Scan(&count); err != nil {
+		t.Fatalf("count original rows: %v", err)
+	}
+	if err := db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='audit_events_v3'`).Scan(&scratch); err != nil {
+		t.Fatalf("count scratch tables: %v", err)
+	}
+	if count != 2 || scratch != 0 {
+		t.Fatalf("rollback state rows=%d scratch=%d", count, scratch)
+	}
+}
+
+func TestSQLiteMigrationPreservesMinimumRowID(t *testing.T) {
+	dataDir := t.TempDir()
+	dbPath := createLegacyAuditFixture(t, dataDir, []legacyAuditFixtureRow{{
+		id: "minimum-rowid", timestamp: int64(1_735_689_600), user: "operator", signature: nil,
+	}})
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy fixture: %v", err)
+	}
+	if _, err := db.Exec(`UPDATE audit_events SET rowid = ? WHERE id = ?`, int64(-1<<63), "minimum-rowid"); err != nil {
+		_ = db.Close()
+		t.Fatalf("assign minimum rowid: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("close legacy fixture: %v", err)
+	}
+
+	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{
+		DataDir: dataDir, SigningKey: []byte("0123456789abcdef0123456789abcdef"),
+		RetentionDays: 0, RetentionConfigured: true,
+	})
+	if err != nil {
+		t.Fatalf("migrate minimum rowid: %v", err)
+	}
+	defer logger.Close()
+	events, err := logger.Query(QueryFilter{})
+	if err != nil || len(events) != 1 || events[0].ID != "minimum-rowid" {
+		t.Fatalf("migrated rows = %+v, err %v", events, err)
+	}
+}

--- a/pkg/audit/sqlite_logger.go
+++ b/pkg/audit/sqlite_logger.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -64,9 +65,10 @@ const (
 
 var auditSQLiteRetryDelays = []time.Duration{25 * time.Millisecond, 75 * time.Millisecond}
 var auditSQLiteRetrySleep = time.Sleep
+var auditMigrationBeforeInsert = func(canonicalAuditRow) error { return nil }
 
 const (
-	auditSchemaVersion               = 2
+	auditSchemaVersion               = 3
 	auditTimestampMigrationBatchSize = 512
 	defaultAuditCleanupInterval      = 24 * time.Hour
 )
@@ -240,7 +242,7 @@ func NewSQLiteLogger(cfg SQLiteLoggerConfig) (*SQLiteLogger, error) {
 	// Load webhook URLs from config table
 	urls := l.loadWebhookURLs()
 	if len(urls) > 0 {
-		l.webhookDelivery = NewWebhookDelivery(urls)
+		l.webhookDelivery = newWebhookDelivery(urls, l.signer.VerifyResult)
 		l.webhookDelivery.Start()
 	}
 
@@ -268,16 +270,17 @@ func (l *SQLiteLogger) IsPersistentAuditLogger() bool {
 func (l *SQLiteLogger) initSchema() error {
 	schema := `
 	CREATE TABLE IF NOT EXISTS audit_events (
-		id TEXT PRIMARY KEY,
-		timestamp INTEGER NOT NULL,
-		event_type TEXT NOT NULL,
-		user TEXT,
-		ip TEXT,
-		path TEXT,
-		success INTEGER NOT NULL,
-		details TEXT,
-		signature TEXT NOT NULL
-	);
+		id TEXT NOT NULL PRIMARY KEY CHECK (typeof(id) = 'text'),
+		timestamp INTEGER NOT NULL CHECK (typeof(timestamp) = 'integer'),
+		event_type TEXT NOT NULL CHECK (typeof(event_type) = 'text'),
+		user TEXT NOT NULL CHECK (typeof(user) = 'text'),
+		ip TEXT NOT NULL CHECK (typeof(ip) = 'text'),
+		path TEXT NOT NULL CHECK (typeof(path) = 'text'),
+		success INTEGER NOT NULL CHECK (typeof(success) = 'integer' AND success IN (0, 1)),
+		details TEXT NOT NULL CHECK (typeof(details) = 'text'),
+		signature TEXT NOT NULL CHECK (typeof(signature) = 'text'),
+		signature_timestamp TEXT NOT NULL DEFAULT '' CHECK (typeof(signature_timestamp) = 'text')
+	) STRICT;
 
 	CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_events(timestamp);
 	CREATE INDEX IF NOT EXISTS idx_audit_timestamp_id ON audit_events(timestamp DESC, id DESC);
@@ -316,23 +319,24 @@ func (l *SQLiteLogger) initSchema() error {
 		return err
 	}
 
-	return l.migrateLegacyTimestamps()
+	return l.migrateAuditSchema()
 }
 
 type canonicalAuditRow struct {
-	rowID     int64
-	id        string
-	timestamp int64
-	eventType string
-	user      sql.NullString
-	ip        sql.NullString
-	path      sql.NullString
-	success   int
-	details   sql.NullString
-	signature sql.NullString
+	rowID              int64
+	id                 string
+	timestamp          int64
+	eventType          string
+	user               string
+	ip                 string
+	path               string
+	success            int64
+	details            string
+	signature          string
+	signatureTimestamp string
 }
 
-func (l *SQLiteLogger) migrateLegacyTimestamps() error {
+func (l *SQLiteLogger) migrateAuditSchema() error {
 	var migrated int
 	err := withSQLiteRetry("migrate_audit_timestamps", func() error {
 		tx, err := l.db.Begin()
@@ -341,7 +345,7 @@ func (l *SQLiteLogger) migrateLegacyTimestamps() error {
 		}
 		defer func() { _ = tx.Rollback() }()
 
-		needsRebuild, err := auditEventsNeedRebuild(tx)
+		needsRebuild, hasSignatureTimestamp, err := auditEventsNeedRebuild(tx)
 		if err != nil {
 			return err
 		}
@@ -361,65 +365,69 @@ func (l *SQLiteLogger) migrateLegacyTimestamps() error {
 		).Scan(&migrated); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(`DROP TABLE IF EXISTS audit_events_v2`); err != nil {
+		if _, err := tx.Exec(`DROP TABLE IF EXISTS audit_events_v3`); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(`
-			CREATE TABLE audit_events_v2 (
-				id TEXT PRIMARY KEY,
-				timestamp INTEGER NOT NULL,
-				event_type TEXT NOT NULL,
-				user TEXT,
-				ip TEXT,
-				path TEXT,
-				success INTEGER NOT NULL,
-				details TEXT,
-				signature TEXT NOT NULL
-			)`); err != nil {
+			CREATE TABLE audit_events_v3 (
+				id TEXT NOT NULL PRIMARY KEY CHECK (typeof(id) = 'text'),
+				timestamp INTEGER NOT NULL CHECK (typeof(timestamp) = 'integer'),
+				event_type TEXT NOT NULL CHECK (typeof(event_type) = 'text'),
+				user TEXT NOT NULL CHECK (typeof(user) = 'text'),
+				ip TEXT NOT NULL CHECK (typeof(ip) = 'text'),
+				path TEXT NOT NULL CHECK (typeof(path) = 'text'),
+				success INTEGER NOT NULL CHECK (typeof(success) = 'integer' AND success IN (0, 1)),
+				details TEXT NOT NULL CHECK (typeof(details) = 'text'),
+				signature TEXT NOT NULL CHECK (typeof(signature) = 'text'),
+				signature_timestamp TEXT NOT NULL DEFAULT '' CHECK (typeof(signature_timestamp) = 'text')
+			) STRICT`); err != nil {
 			return err
 		}
 
-		lastRowID := int64(-1 << 63)
+		var lastRowID int64
+		firstBatch := true
 		for {
-			rows, err := tx.Query(`
-				SELECT rowid, id, timestamp, event_type, user, ip, path, success, details, signature
-				FROM audit_events
-				WHERE rowid > ?
-				ORDER BY rowid
-				LIMIT ?`, lastRowID, auditTimestampMigrationBatchSize)
+			query := `
+				SELECT rowid, id, timestamp, event_type, user, ip, path, success, details, signature`
+			if hasSignatureTimestamp {
+				query += `, signature_timestamp`
+			}
+			query += ` FROM audit_events`
+			args := []any{}
+			if !firstBatch {
+				query += ` WHERE rowid > ?`
+				args = append(args, lastRowID)
+			}
+			query += ` ORDER BY rowid LIMIT ?`
+			args = append(args, auditTimestampMigrationBatchSize)
+			rows, err := tx.Query(query, args...)
 			if err != nil {
 				return err
 			}
 
 			batch := make([]canonicalAuditRow, 0, auditTimestampMigrationBatchSize)
 			for rows.Next() {
-				var item canonicalAuditRow
-				var value any
-				if err := rows.Scan(
-					&item.rowID,
-					&item.id,
-					&value,
-					&item.eventType,
-					&item.user,
-					&item.ip,
-					&item.path,
-					&item.success,
-					&item.details,
-					&item.signature,
-				); err != nil {
+				var raw [10]any
+				destinations := []any{
+					&raw[0], &raw[1], &raw[2], &raw[3], &raw[4],
+					&raw[5], &raw[6], &raw[7], &raw[8], &raw[9],
+				}
+				if hasSignatureTimestamp {
+					destinations = append(destinations, new(any))
+				}
+				if err := rows.Scan(destinations...); err != nil {
 					rows.Close()
 					return &auditStoreDataError{field: "row"}
 				}
-				timestamp, err := parseAuditTimestamp(value)
+				var signatureTimestamp any
+				if hasSignatureTimestamp {
+					signatureTimestamp = *(destinations[len(destinations)-1].(*any))
+				}
+				item, err := canonicalizeMigratedAuditRow(raw, signatureTimestamp, hasSignatureTimestamp)
 				if err != nil {
 					rows.Close()
-					return &auditStoreDataError{field: "timestamp"}
+					return err
 				}
-				if item.id == "" || item.eventType == "" || (item.success != 0 && item.success != 1) {
-					rows.Close()
-					return &auditStoreDataError{field: "row"}
-				}
-				item.timestamp = timestamp.Unix()
 				batch = append(batch, item)
 			}
 			if err := rows.Err(); err != nil {
@@ -434,10 +442,13 @@ func (l *SQLiteLogger) migrateLegacyTimestamps() error {
 			}
 
 			for _, item := range batch {
+				if err := auditMigrationBeforeInsert(item); err != nil {
+					return err
+				}
 				if _, err := tx.Exec(
-					`INSERT INTO audit_events_v2
-						(id, timestamp, event_type, user, ip, path, success, details, signature)
-					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+					`INSERT INTO audit_events_v3
+						(id, timestamp, event_type, user, ip, path, success, details, signature, signature_timestamp)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 					item.id,
 					item.timestamp,
 					item.eventType,
@@ -446,18 +457,20 @@ func (l *SQLiteLogger) migrateLegacyTimestamps() error {
 					item.path,
 					item.success,
 					item.details,
-					item.signature.String,
+					item.signature,
+					item.signatureTimestamp,
 				); err != nil {
 					return err
 				}
 			}
 			lastRowID = batch[len(batch)-1].rowID
+			firstBatch = false
 		}
 
 		if _, err := tx.Exec(`DROP TABLE audit_events`); err != nil {
 			return err
 		}
-		if _, err := tx.Exec(`ALTER TABLE audit_events_v2 RENAME TO audit_events`); err != nil {
+		if _, err := tx.Exec(`ALTER TABLE audit_events_v3 RENAME TO audit_events`); err != nil {
 			return err
 		}
 		if _, err := tx.Exec(`
@@ -480,26 +493,147 @@ func (l *SQLiteLogger) migrateLegacyTimestamps() error {
 		return tx.Commit()
 	})
 	if err != nil {
-		return fmt.Errorf("normalize audit timestamp storage: %w", err)
+		return fmt.Errorf("normalize audit event storage: %w", err)
 	}
 	if migrated > 0 {
 		log.Info().
 			Int("rows", migrated).
-			Msg("Normalized legacy audit timestamp storage")
+			Msg("Normalized legacy audit event storage")
 	}
 	return nil
 }
 
-func auditEventsNeedRebuild(tx *sql.Tx) (bool, error) {
+func canonicalizeMigratedAuditRow(raw [10]any, rawSignatureTimestamp any, hasSignatureTimestamp bool) (canonicalAuditRow, error) {
+	rowID, ok := raw[0].(int64)
+	if !ok {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	id, err := migratedRequiredString(raw[1])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	timestamp, derivedSignatureTimestamp, err := migratedTimestamp(raw[2])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "timestamp"}
+	}
+	eventType, err := migratedRequiredString(raw[3])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	user, err := migratedNullableString(raw[4])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	ip, err := migratedNullableString(raw[5])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	path, err := migratedNullableString(raw[6])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	success, ok := raw[7].(int64)
+	if !ok || (success != 0 && success != 1) {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	details, err := migratedNullableString(raw[8])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+	signature, err := migratedNullableString(raw[9])
+	if err != nil {
+		return canonicalAuditRow{}, &auditStoreDataError{field: "row"}
+	}
+
+	signatureTimestamp := derivedSignatureTimestamp
+	if hasSignatureTimestamp {
+		signatureTimestamp, err = migratedRequiredString(rawSignatureTimestamp)
+		if err != nil || !isCanonicalSignatureTimestamp(signatureTimestamp, timestamp) {
+			return canonicalAuditRow{}, &auditStoreDataError{field: "signature timestamp"}
+		}
+	}
+
+	return canonicalAuditRow{
+		rowID:              rowID,
+		id:                 id,
+		timestamp:          timestamp,
+		eventType:          eventType,
+		user:               user,
+		ip:                 ip,
+		path:               path,
+		success:            success,
+		details:            details,
+		signature:          signature,
+		signatureTimestamp: signatureTimestamp,
+	}, nil
+}
+
+func migratedRequiredString(value any) (string, error) {
+	text, ok := value.(string)
+	if !ok {
+		return "", errors.New("not text")
+	}
+	return text, nil
+}
+
+func migratedNullableString(value any) (string, error) {
+	if value == nil {
+		return "", nil
+	}
+	return migratedRequiredString(value)
+}
+
+func migratedTimestamp(value any) (int64, string, error) {
+	var preserveCanonical bool
+	switch v := value.(type) {
+	case time.Time, string, []byte:
+		preserveCanonical = true
+	case int64, int, int32:
+	case float64:
+		// Permissive historical tables allowed SQLite REAL timestamps and the
+		// previous migration normalized them by truncating toward zero. Preserve
+		// that compatibility only while the conversion is finite and in range;
+		// the rebuilt STRICT table stores the result as canonical INTEGER.
+		const maxInt64Exclusive = 9223372036854775808.0
+		if math.IsNaN(v) || math.IsInf(v, 0) || v < math.MinInt64 || v >= maxInt64Exclusive {
+			return 0, "", errors.New("REAL timestamp is non-finite or outside int64 range")
+		}
+	default:
+		return 0, "", errors.New("noncanonical timestamp type")
+	}
+	timestamp, err := parseAuditTimestamp(value)
+	if err != nil {
+		return 0, "", err
+	}
+	canonical := ""
+	if preserveCanonical {
+		canonical = timestamp.UTC().Format(time.RFC3339Nano)
+	}
+	return timestamp.Unix(), canonical, nil
+}
+
+func isCanonicalSignatureTimestamp(value string, unix int64) bool {
+	if value == "" {
+		return true
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil || parsed.Unix() != unix {
+		return false
+	}
+	return parsed.UTC().Format(time.RFC3339Nano) == value
+}
+
+func auditEventsNeedRebuild(tx *sql.Tx) (bool, bool, error) {
 	rows, err := tx.Query(`PRAGMA table_info(audit_events)`)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	defer rows.Close()
 
 	columns := make(map[string]struct {
 		columnType string
 		notNull    bool
+		primaryKey bool
 	})
 	for rows.Next() {
 		var position int
@@ -514,38 +648,60 @@ func auditEventsNeedRebuild(tx *sql.Tx) (bool, error) {
 			&defaultValue,
 			&primaryKey,
 		); err != nil {
-			return false, &auditStoreDataError{field: "schema"}
+			return false, false, &auditStoreDataError{field: "schema"}
 		}
 		columns[name] = struct {
 			columnType string
 			notNull    bool
-		}{columnType: strings.ToUpper(columnType), notNull: notNull != 0}
+			primaryKey bool
+		}{columnType: strings.ToUpper(columnType), notNull: notNull != 0, primaryKey: primaryKey != 0}
 	}
 	if err := rows.Err(); err != nil {
-		return false, err
+		return false, false, err
 	}
 
-	timestamp, timestampOK := columns["timestamp"]
-	signature, signatureOK := columns["signature"]
-	if !timestampOK || !signatureOK {
-		return false, &auditStoreDataError{field: "schema"}
+	requiredTypes := map[string]string{
+		"id": "TEXT", "timestamp": "INTEGER", "event_type": "TEXT",
+		"user": "TEXT", "ip": "TEXT", "path": "TEXT", "success": "INTEGER",
+		"details": "TEXT", "signature": "TEXT", "signature_timestamp": "TEXT",
 	}
-	if timestamp.columnType != "INTEGER" || !timestamp.notNull || !signature.notNull {
-		return true, nil
+	_, hasSignatureTimestamp := columns["signature_timestamp"]
+	for name, columnType := range requiredTypes {
+		column, ok := columns[name]
+		if !ok {
+			if name == "signature_timestamp" {
+				continue
+			}
+			return false, hasSignatureTimestamp, &auditStoreDataError{field: "schema"}
+		}
+		if column.columnType != columnType || !column.notNull || (name == "id" && !column.primaryKey) {
+			return true, hasSignatureTimestamp, nil
+		}
 	}
 
-	var hasNonInteger int
+	var schemaSQL string
 	if err := tx.QueryRow(
-		`SELECT EXISTS(SELECT 1 FROM audit_events WHERE typeof(timestamp) != 'integer')`,
-	).Scan(&hasNonInteger); err != nil {
-		return false, err
+		`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'audit_events'`,
+	).Scan(&schemaSQL); err != nil {
+		return false, hasSignatureTimestamp, err
 	}
-	return hasNonInteger != 0, nil
+	normalized := strings.ToLower(schemaSQL)
+	for _, required := range []string{
+		"strict", "typeof(timestamp) = 'integer'", "typeof(success) = 'integer'",
+		"success in (0, 1)", "typeof(signature_timestamp) = 'text'",
+	} {
+		if !strings.Contains(normalized, required) {
+			return true, hasSignatureTimestamp, nil
+		}
+	}
+	return false, hasSignatureTimestamp, nil
 }
 
 // Log records an audit event with HMAC signature.
 func (l *SQLiteLogger) Record(event Event) error {
-	// Sign the event
+	// The persistent tuple has one timestamp and historical-evidence encoding.
+	event.Timestamp = time.Unix(event.Timestamp.Unix(), 0).UTC()
+	event.SignatureTimestamp = ""
 	event.Signature = l.signer.Sign(event)
 
 	// Insert into database
@@ -560,8 +716,8 @@ func (l *SQLiteLogger) Record(event Event) error {
 		defer l.mu.Unlock()
 
 		_, err = l.db.Exec(`
-			INSERT INTO audit_events (id, timestamp, event_type, user, ip, path, success, details, signature)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			INSERT INTO audit_events (id, timestamp, event_type, user, ip, path, success, details, signature, signature_timestamp)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			event.ID,
 			event.Timestamp.Unix(),
 			event.EventType,
@@ -571,6 +727,7 @@ func (l *SQLiteLogger) Record(event Event) error {
 			success,
 			event.Details,
 			event.Signature,
+			event.SignatureTimestamp,
 		)
 		return err
 	})
@@ -631,7 +788,7 @@ type auditSQLReader interface {
 }
 
 func queryAuditEvents(reader auditSQLReader, filter QueryFilter) ([]Event, error) {
-	query := "SELECT id, timestamp, event_type, user, ip, path, success, details, signature FROM audit_events WHERE 1=1"
+	query := "SELECT id, timestamp, event_type, user, ip, path, success, details, signature, signature_timestamp FROM audit_events WHERE 1=1"
 	args := []interface{}{}
 
 	if filter.ID != "" {
@@ -686,32 +843,86 @@ func queryAuditEvents(reader auditSQLReader, filter QueryFilter) ([]Event, error
 
 	events := make([]Event, 0)
 	for rows.Next() {
-		var e Event
-		var timestampValue any
-		var success int
-		var user, ip, path, details, signature sql.NullString
-
-		err := rows.Scan(&e.ID, &timestampValue, &e.EventType, &user, &ip, &path, &success, &details, &signature)
+		var raw [10]any
+		destinations := make([]any, len(raw))
+		for i := range raw {
+			destinations[i] = &raw[i]
+		}
+		if err := rows.Scan(destinations...); err != nil {
+			return nil, fmt.Errorf("failed to scan audit event: %w", err)
+		}
+		e, err := decodeCanonicalAuditEvent(raw)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan audit event: %w", err)
 		}
-		timestamp, err := parseAuditTimestamp(timestampValue)
-		if err != nil {
-			return nil, fmt.Errorf("failed to scan audit event: %w", err)
-		}
-
-		e.Timestamp = timestamp
-		e.Success = success == 1
-		e.User = user.String
-		e.IP = ip.String
-		e.Path = path.String
-		e.Details = details.String
-		e.Signature = signature.String
-
 		events = append(events, e)
 	}
 
 	return events, rows.Err()
+}
+
+func decodeCanonicalAuditEvent(raw [10]any) (Event, error) {
+	text := func(value any) (string, error) {
+		result, ok := value.(string)
+		if !ok {
+			return "", &auditStoreDataError{field: "row"}
+		}
+		return result, nil
+	}
+
+	id, err := text(raw[0])
+	if err != nil {
+		return Event{}, err
+	}
+	timestamp, ok := raw[1].(int64)
+	if !ok {
+		return Event{}, &auditStoreDataError{field: "timestamp"}
+	}
+	eventType, err := text(raw[2])
+	if err != nil {
+		return Event{}, err
+	}
+	user, err := text(raw[3])
+	if err != nil {
+		return Event{}, err
+	}
+	ip, err := text(raw[4])
+	if err != nil {
+		return Event{}, err
+	}
+	path, err := text(raw[5])
+	if err != nil {
+		return Event{}, err
+	}
+	success, ok := raw[6].(int64)
+	if !ok || (success != 0 && success != 1) {
+		return Event{}, &auditStoreDataError{field: "success"}
+	}
+	details, err := text(raw[7])
+	if err != nil {
+		return Event{}, err
+	}
+	signature, err := text(raw[8])
+	if err != nil {
+		return Event{}, err
+	}
+	signatureTimestamp, err := text(raw[9])
+	if err != nil || !isCanonicalSignatureTimestamp(signatureTimestamp, timestamp) {
+		return Event{}, &auditStoreDataError{field: "signature timestamp"}
+	}
+
+	return Event{
+		ID:                 id,
+		Timestamp:          time.Unix(timestamp, 0).UTC(),
+		EventType:          eventType,
+		User:               user,
+		IP:                 ip,
+		Path:               path,
+		Success:            success == 1,
+		Details:            details,
+		Signature:          signature,
+		SignatureTimestamp: signatureTimestamp,
+	}, nil
 }
 
 // QueryPage reads events and their matching count from one SQLite snapshot.
@@ -905,7 +1116,7 @@ func (l *SQLiteLogger) UpdateWebhookURLs(urls []string) error {
 	// Update delivery worker
 	if len(urls) > 0 {
 		if l.webhookDelivery == nil {
-			l.webhookDelivery = NewWebhookDelivery(urls)
+			l.webhookDelivery = newWebhookDelivery(urls, l.signer.VerifyResult)
 			l.webhookDelivery.Start()
 		} else {
 			l.webhookDelivery.UpdateURLs(urls)
@@ -921,6 +1132,11 @@ func (l *SQLiteLogger) UpdateWebhookURLs(urls []string) error {
 // VerifySignature checks if an event's signature is valid.
 func (l *SQLiteLogger) VerifySignature(event Event) bool {
 	return l.signer.Verify(event)
+}
+
+// VerifySignatureResult returns the signature version and evidence assurance.
+func (l *SQLiteLogger) VerifySignatureResult(event Event) SignatureVerification {
+	return l.signer.VerifyResult(event)
 }
 
 // Close gracefully shuts down the logger.

--- a/pkg/audit/sqlite_logger_migration_test.go
+++ b/pkg/audit/sqlite_logger_migration_test.go
@@ -254,7 +254,7 @@ func TestSQLiteLoggerLegacyMigrationRollsBackMalformedRows(t *testing.T) {
 	}
 	var scratchTables int
 	if err := db.QueryRow(`
-		SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'audit_events_v2'
+		SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'audit_events_v3'
 	`).Scan(&scratchTables); err != nil {
 		t.Fatalf("check migration scratch table: %v", err)
 	}

--- a/pkg/audit/sqlite_logger_test.go
+++ b/pkg/audit/sqlite_logger_test.go
@@ -1,7 +1,6 @@
 package audit
 
 import (
-	"database/sql"
 	"errors"
 	"fmt"
 	"testing"
@@ -301,7 +300,7 @@ func TestSQLiteLoggerQuery(t *testing.T) {
 	})
 }
 
-func TestSQLiteLoggerQueryHandlesLegacyDatetimeTimestampRows(t *testing.T) {
+func TestSQLiteLoggerCanonicalSchemaRejectsLegacyDatetimeTimestampRows(t *testing.T) {
 	tempDir := t.TempDir()
 
 	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{
@@ -321,29 +320,18 @@ func TestSQLiteLoggerQueryHandlesLegacyDatetimeTimestampRows(t *testing.T) {
 		"legacy-datetime",
 		legacyTime,
 		"startup",
-		sql.NullString{},
-		sql.NullString{},
+		"",
+		"",
 		"/api/audit",
 		1,
 		"legacy Pro runtime timestamp",
 		"legacy-signature",
-	); err != nil {
-		t.Fatalf("insert legacy datetime row: %v", err)
-	}
-
-	events, err := logger.Query(QueryFilter{ID: "legacy-datetime", Limit: 1})
-	if err != nil {
-		t.Fatalf("Query failed for legacy datetime timestamp row: %v", err)
-	}
-	if len(events) != 1 {
-		t.Fatalf("Expected 1 event, got %d", len(events))
-	}
-	if !events[0].Timestamp.Equal(legacyTime) {
-		t.Fatalf("timestamp = %s, want %s", events[0].Timestamp, legacyTime)
+	); err == nil {
+		t.Fatal("canonical schema accepted a legacy datetime timestamp after migration")
 	}
 }
 
-func TestSQLiteLoggerQueryHandlesLegacyGoMonotonicTimestampRows(t *testing.T) {
+func TestSQLiteLoggerCanonicalSchemaRejectsLegacyGoMonotonicTimestampRows(t *testing.T) {
 	tempDir := t.TempDir()
 
 	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{
@@ -357,32 +345,20 @@ func TestSQLiteLoggerQueryHandlesLegacyGoMonotonicTimestampRows(t *testing.T) {
 	defer logger.Close()
 
 	const legacyTimestamp = "2026-07-05 08:51:23.65653076 +0000 UTC m=+0.009025344"
-	want := time.Date(2026, 7, 5, 8, 51, 23, 656530760, time.UTC)
 	if _, err := logger.db.Exec(`
 		INSERT INTO audit_events (id, timestamp, event_type, user, ip, path, success, details, signature)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		"legacy-go-monotonic",
 		legacyTimestamp,
 		"startup",
-		sql.NullString{},
-		sql.NullString{},
+		"",
+		"",
 		"/api/audit",
 		1,
 		"legacy Go monotonic timestamp",
 		"legacy-signature",
-	); err != nil {
-		t.Fatalf("insert legacy Go monotonic row: %v", err)
-	}
-
-	events, err := logger.Query(QueryFilter{ID: "legacy-go-monotonic", Limit: 1})
-	if err != nil {
-		t.Fatalf("Query failed for legacy Go monotonic timestamp row: %v", err)
-	}
-	if len(events) != 1 {
-		t.Fatalf("Expected 1 event, got %d", len(events))
-	}
-	if !events[0].Timestamp.Equal(want) {
-		t.Fatalf("timestamp = %s, want %s", events[0].Timestamp, want)
+	); err == nil {
+		t.Fatal("canonical schema accepted a legacy monotonic timestamp after migration")
 	}
 }
 

--- a/pkg/audit/sqlite_signature_security_test.go
+++ b/pkg/audit/sqlite_signature_security_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-func TestSQLiteV2AndLegacySignaturesSurviveRestartQueryAndExport(t *testing.T) {
+func TestSQLiteCurrentAndLegacySignaturesSurviveRestartQueryAndExport(t *testing.T) {
 	dataDir := t.TempDir()
 	signingKey := []byte("0123456789abcdef0123456789abcdef")
 	logger, err := NewSQLiteLogger(SQLiteLoggerConfig{DataDir: dataDir, SigningKey: signingKey})
@@ -16,8 +16,8 @@ func TestSQLiteV2AndLegacySignaturesSurviveRestartQueryAndExport(t *testing.T) {
 		t.Fatalf("NewSQLiteLogger: %v", err)
 	}
 
-	v2Event := Event{
-		ID:        "v2-event",
+	currentEvent := Event{
+		ID:        "v3-event",
 		Timestamp: time.Unix(1_725_555_555, 987_654_321).UTC(),
 		EventType: "security|alert",
 		User:      "監査\noperator",
@@ -26,8 +26,8 @@ func TestSQLiteV2AndLegacySignaturesSurviveRestartQueryAndExport(t *testing.T) {
 		Success:   true,
 		Details:   "line one\nline two|done",
 	}
-	if err := logger.Record(v2Event); err != nil {
-		t.Fatalf("Record v2 event: %v", err)
+	if err := logger.Record(currentEvent); err != nil {
+		t.Fatalf("Record v3 event: %v", err)
 	}
 
 	legacyEvent := Event{
@@ -80,8 +80,8 @@ func TestSQLiteV2AndLegacySignaturesSurviveRestartQueryAndExport(t *testing.T) {
 			t.Fatalf("signature for %s did not verify after restart", event.ID)
 		}
 	}
-	if versions[v2Event.ID] != SignatureVersionV2 {
-		t.Fatalf("new SQLite row version = %q, want v2", versions[v2Event.ID])
+	if versions[currentEvent.ID] != SignatureVersionV3 {
+		t.Fatalf("new SQLite row version = %q, want v3", versions[currentEvent.ID])
 	}
 	if versions[legacyEvent.ID] != SignatureVersionLegacy {
 		t.Fatalf("historical SQLite row version = %q, want legacy", versions[legacyEvent.ID])
@@ -113,6 +113,12 @@ func TestSQLiteV2AndLegacySignaturesSurviveRestartQueryAndExport(t *testing.T) {
 		if event.SignatureValid == nil || !*event.SignatureValid {
 			t.Fatalf("JSON export signature verdict for %s = %v", event.ID, event.SignatureValid)
 		}
+		if event.ID == currentEvent.ID && (event.SignatureStatus != VerificationStatusStrong || event.SignatureAssurance != SignatureAssuranceStrong) {
+			t.Fatalf("current export assurance = %s/%s", event.SignatureStatus, event.SignatureAssurance)
+		}
+		if event.ID == legacyEvent.ID && (event.SignatureStatus != VerificationStatusCompatibility || event.SignatureAssurance != SignatureAssuranceCompatibility) {
+			t.Fatalf("legacy export assurance = %s/%s", event.SignatureStatus, event.SignatureAssurance)
+		}
 	}
 
 	csvResult, err := exporter.Export(QueryFilter{}, ExportFormatCSV, true)
@@ -127,16 +133,16 @@ func TestSQLiteV2AndLegacySignaturesSurviveRestartQueryAndExport(t *testing.T) {
 		t.Fatalf("CSV records = %d, want header plus 2 rows", len(records))
 	}
 	for _, row := range records[1:] {
-		if row[len(row)-1] != "true" {
-			t.Fatalf("CSV signature verdict for %s = %q", row[0], row[len(row)-1])
+		if row[len(row)-3] != "true" {
+			t.Fatalf("CSV signature verdict for %s = %q", row[0], row[len(row)-3])
 		}
-		if DetectSignatureVersion(row[len(row)-2]) == SignatureVersionUnknown {
+		if SignatureVersion(row[len(row)-4]) == SignatureVersionUnknown || DetectSignatureVersion(row[len(row)-5]) == SignatureVersionUnknown {
 			t.Fatalf("CSV signature for %s lost its identifiable envelope", row[0])
 		}
 	}
 }
 
-func TestTenantSQLiteFactoryWritesV2Signatures(t *testing.T) {
+func TestTenantSQLiteFactoryWritesV3Signatures(t *testing.T) {
 	manager := NewTenantLoggerManager(t.TempDir(), &SQLiteLoggerFactory{
 		CryptoMgr: newMockCryptoManager(),
 	})
@@ -152,14 +158,14 @@ func TestTenantSQLiteFactoryWritesV2Signatures(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("tenant events = %d, want 1", len(events))
 	}
-	if DetectSignatureVersion(events[0].Signature) != SignatureVersionV2 {
-		t.Fatalf("tenant signature version = %q, want v2", DetectSignatureVersion(events[0].Signature))
+	if DetectSignatureVersion(events[0].Signature) != SignatureVersionV3 {
+		t.Fatalf("tenant signature version = %q, want v3", DetectSignatureVersion(events[0].Signature))
 	}
 	logger, ok := manager.GetLogger("tenant-a").(*SQLiteLogger)
 	if !ok {
 		t.Fatalf("tenant logger type = %T, want *SQLiteLogger", manager.GetLogger("tenant-a"))
 	}
 	if !logger.VerifySignature(events[0]) {
-		t.Fatal("tenant v2 signature did not verify")
+		t.Fatal("tenant v3 signature did not verify")
 	}
 }

--- a/pkg/audit/verification.go
+++ b/pkg/audit/verification.go
@@ -1,0 +1,55 @@
+package audit
+
+// EventProjection is the API representation of an audit event with its
+// authoritative signature version, status, and assurance. SignatureValid is a
+// compatibility field; clients must not use it to equate compatibility and
+// strong evidence.
+type EventProjection struct {
+	Event
+	SignatureVersion   SignatureVersion   `json:"signature_version"`
+	SignatureStatus    VerificationStatus `json:"signature_status"`
+	SignatureAssurance SignatureAssurance `json:"signature_assurance"`
+	SignatureValid     *bool              `json:"signature_valid,omitempty"`
+}
+
+// ProjectEvent classifies one event for API and UI consumers.
+func ProjectEvent(event Event, verifier any) EventProjection {
+	result := ClassifySignature(verifier, event)
+	projection := EventProjection{
+		Event:              event,
+		SignatureVersion:   result.Version,
+		SignatureStatus:    result.Status,
+		SignatureAssurance: result.Assurance,
+	}
+	if result.Status != VerificationStatusUnsigned {
+		valid := result.Verified
+		projection.SignatureValid = &valid
+	}
+	return projection
+}
+
+// ProjectEvents classifies an event page without changing its ordering.
+func ProjectEvents(events []Event, verifier any) []EventProjection {
+	projected := make([]EventProjection, len(events))
+	for i, event := range events {
+		projected[i] = ProjectEvent(event, verifier)
+	}
+	return projected
+}
+
+// VerificationMessage is the operator-facing explanation for a classified
+// signature result.
+func VerificationMessage(result SignatureVerification) string {
+	switch result.Status {
+	case VerificationStatusStrong:
+		return "Event signature strongly verified"
+	case VerificationStatusCompatibility:
+		return "Historical signature verified with compatibility assurance only"
+	case VerificationStatusInvalid:
+		return "Event signature verification failed"
+	case VerificationStatusUnsigned:
+		return "Event is unsigned"
+	default:
+		return "Signature version is unknown or the verification key is unavailable"
+	}
+}

--- a/pkg/audit/webhook.go
+++ b/pkg/audit/webhook.go
@@ -29,26 +29,38 @@ var resolveWebhookIPs = net.DefaultResolver.LookupIPAddr
 
 // WebhookDelivery handles async webhook delivery with retries.
 type WebhookDelivery struct {
-	mu       sync.RWMutex
-	urls     []string
-	client   *http.Client
-	queue    chan Event
-	stopChan chan struct{}
-	stopOnce sync.Once
-	wg       sync.WaitGroup
+	mu                sync.RWMutex
+	urls              []string
+	client            *http.Client
+	classifySignature func(Event) SignatureVerification
+	queue             chan Event
+	stopChan          chan struct{}
+	stopOnce          sync.Once
+	wg                sync.WaitGroup
 }
 
 // WebhookPayload is the JSON payload sent to webhooks.
 type WebhookPayload struct {
-	Event     string    `json:"event"`
-	Timestamp time.Time `json:"timestamp"`
-	Data      Event     `json:"data"`
+	Event              string             `json:"event"`
+	Timestamp          time.Time          `json:"timestamp"`
+	SignatureVersion   SignatureVersion   `json:"signature_version"`
+	SignatureStatus    VerificationStatus `json:"signature_status"`
+	SignatureAssurance SignatureAssurance `json:"signature_assurance"`
+	Data               Event              `json:"data"`
 }
 
 // NewWebhookDelivery creates a new webhook delivery worker.
 func NewWebhookDelivery(urls []string) *WebhookDelivery {
+	return newWebhookDelivery(urls, nil)
+}
+
+// newWebhookDelivery binds authoritative verification to delivery. The
+// exported constructor deliberately has no verifier and therefore cannot make
+// an assurance claim for directly enqueued or replayed events.
+func newWebhookDelivery(urls []string, classify func(Event) SignatureVerification) *WebhookDelivery {
 	return &WebhookDelivery{
-		urls: urls,
+		urls:              urls,
+		classifySignature: classify,
 		client: securityutil.NewRestrictedOutboundHTTPClient(webhookTimeout, securityutil.RestrictedOutboundHTTPOptions{
 			AllowedSchemes: []string{"http", "https"},
 			ResolveIPAddrs: resolveWebhookIPs,
@@ -204,10 +216,14 @@ func (w *WebhookDelivery) deliverWithRetry(url string, event Event) error {
 
 // deliver sends a single event to a webhook URL.
 func (w *WebhookDelivery) deliver(url string, event Event) error {
+	verification := w.verificationForEvent(event)
 	payload := WebhookPayload{
-		Event:     "audit." + event.EventType,
-		Timestamp: event.Timestamp,
-		Data:      event,
+		Event:              "audit." + event.EventType,
+		Timestamp:          event.Timestamp,
+		SignatureVersion:   verification.Version,
+		SignatureStatus:    verification.Status,
+		SignatureAssurance: verification.Assurance,
+		Data:               event,
 	}
 
 	body, err := json.Marshal(payload)
@@ -248,6 +264,26 @@ func (w *WebhookDelivery) deliver(url string, event Event) error {
 	}
 
 	return nil
+}
+
+func (w *WebhookDelivery) verificationForEvent(event Event) SignatureVerification {
+	fallback := unverifiedWebhookSignature(event)
+	if w.classifySignature == nil {
+		return fallback
+	}
+	verification := w.classifySignature(event)
+	if verification.Version != fallback.Version {
+		return fallback
+	}
+	return verification
+}
+
+func unverifiedWebhookSignature(event Event) SignatureVerification {
+	version := DetectSignatureVersion(event.Signature)
+	if version == SignatureVersionUnsigned {
+		return signatureVerification(VerificationStatusUnsigned, version, SignatureAssuranceNone, false)
+	}
+	return signatureVerification(VerificationStatusUnknown, version, SignatureAssuranceNone, false)
 }
 
 func validateWebhookURL(ctx context.Context, rawURL string) error {

--- a/pkg/audit/webhook_delivery_test.go
+++ b/pkg/audit/webhook_delivery_test.go
@@ -34,6 +34,11 @@ func TestWebhookDeliveryDeliverWithRetry(t *testing.T) {
 		Path:      "/api/login",
 		Success:   true,
 	}
+	signer, err := NewSignerWithKey([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("NewSignerWithKey: %v", err)
+	}
+	event.Signature = signer.Sign(event)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempts++
@@ -63,6 +68,11 @@ func TestWebhookDeliveryDeliverWithRetry(t *testing.T) {
 		if payload.Data.ID != event.ID {
 			t.Fatalf("expected payload event id %q, got %q", event.ID, payload.Data.ID)
 		}
+		if payload.SignatureVersion != SignatureVersionV3 ||
+			payload.SignatureStatus != VerificationStatusStrong ||
+			payload.SignatureAssurance != SignatureAssuranceStrong {
+			t.Fatalf("unexpected signature assurance: %+v", payload)
+		}
 
 		if attempts < 3 {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -87,7 +97,7 @@ func TestWebhookDeliveryDeliverWithRetry(t *testing.T) {
 		},
 	}
 
-	delivery := NewWebhookDelivery([]string{"http://" + targetHost + "/audit"})
+	delivery := newWebhookDelivery([]string{"http://" + targetHost + "/audit"}, signer.VerifyResult)
 	delivery.client = &http.Client{Transport: transport}
 
 	if err := delivery.deliverWithRetry("http://"+targetHost+"/audit", event); err != nil {
@@ -95,6 +105,30 @@ func TestWebhookDeliveryDeliverWithRetry(t *testing.T) {
 	}
 	if attempts != 3 {
 		t.Fatalf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestWebhookDeliveryAssuranceRequiresAuthoritativeVerification(t *testing.T) {
+	signer, err := NewSignerWithKey([]byte("0123456789abcdef0123456789abcdef"))
+	if err != nil {
+		t.Fatalf("NewSignerWithKey: %v", err)
+	}
+	event := Event{ID: "proof", EventType: "login", Timestamp: time.Unix(123, 0), Success: true}
+	event.Signature = signer.Sign(event)
+
+	unverified := NewWebhookDelivery(nil).verificationForEvent(event)
+	if unverified.Status != VerificationStatusUnknown || unverified.Assurance != SignatureAssuranceNone || unverified.Verified {
+		t.Fatalf("unverified delivery result = %+v", unverified)
+	}
+
+	delivery := newWebhookDelivery(nil, signer.VerifyResult)
+	if verified := delivery.verificationForEvent(event); verified.Status != VerificationStatusStrong || verified.Assurance != SignatureAssuranceStrong || !verified.Verified {
+		t.Fatalf("verified delivery result = %+v", verified)
+	}
+
+	event.Details = "tampered"
+	if invalid := delivery.verificationForEvent(event); invalid.Status != VerificationStatusInvalid || invalid.Assurance != SignatureAssuranceNone || invalid.Verified {
+		t.Fatalf("tampered delivery result = %+v", invalid)
 	}
 }
 

--- a/tests/migration/v5_session_db_test.go
+++ b/tests/migration/v5_session_db_test.go
@@ -460,7 +460,7 @@ func TestV5DataDir_AuditDBSchemaAutoMigration(t *testing.T) {
 
 	var version int
 	require.NoError(t, db.QueryRow("SELECT version FROM schema_version ORDER BY version DESC LIMIT 1").Scan(&version))
-	assert.Equal(t, 2, version, "schema_version should be 2")
+	assert.Equal(t, 3, version, "schema_version should be 3")
 }
 
 // TestV5DataDir_AuditDBPreExistingData verifies that the v6 audit logger


### PR DESCRIPTION
## Summary

- introduce a cryptographically domain-separated `v3` audit signature over the exact canonical persisted tuple
- preserve legacy, v2, and fractional RFC3339Nano evidence with explicit compatibility assurance through a transactional STRICT SQLite migration
- fail closed on malformed envelopes and noncanonical SQLite values
- propagate strong, compatibility, invalid, unknown, and unsigned states through APIs, exports, summaries, webhooks, UI, and operator documentation

## Security evidence

- retains the cross-event v2-prefix-stripping reproduction and proves v3 cannot verify in any accepted historic domain
- covers field tampering, binary and delimiter content, malformed/unknown envelopes, historic Unix and fractional timestamps, migration rollback, and raw SQLite representation mutations
- independent exact-candidate review completed; its tooltip-state finding was fixed with regression coverage

## Validation

- `go test -race ./pkg/audit -count=1`
- focused API and migration suites
- `go vet ./pkg/audit ./internal/api ./tests/migration`
- `govulncheck ./...` (no reachable vulnerabilities)
- focused `gosec` G115 scan (clean)
- frontend assurance suites, lint, type-check, format check, and production build

Enterprise composition and release controls are pinned to exact commit `f2b13904f53ae061cd8088fa20d804591f98a09c` in the companion pull request.

No release, artifact publication, or deployment is part of this change.
