### PR TITLE
Make E2E tier checker launcher portable

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,9 +36,13 @@ permissions:
 
 jobs:
   tier-selection:
-    name: Validate E2E tier selection
-    runs-on: ubuntu-24.04
+    name: Validate E2E tier selection (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-2025]
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -56,7 +60,9 @@ jobs:
 
       - name: Validate stable/probation project accounting
         working-directory: tests/integration
-        run: npm run check:e2e-tiers
+        run: |
+          npm run test:check:e2e-tiers
+          npm run check:e2e-tiers
 
   e2e:
     name: Playwright Core E2E (shard ${{ matrix.shard }}/8)

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -91,6 +91,8 @@ cd tests/integration
 npm run check:e2e-tiers
 ```
 
+This shell-free command uses the repository-pinned Playwright JavaScript CLI and is validated on native Unix and Windows runners.
+
 The check uses Playwright's own `--list` output, verifies that stable and
 probation are disjoint and exhaustive across every configured project, rejects
 stale/duplicate/overlapping ledger entries, and protects a minimum stable-tier

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "node ./scripts/run-playwright.mjs",
     "check:e2e-tiers": "node ./scripts/check-e2e-tiering.mjs",
+    "test:check:e2e-tiers": "node --test ./scripts/check-e2e-tiering.test.mjs",
     "evals": "node ./scripts/run-evals.mjs",
     "test:visual": "npm test -- tests/06-theme-visual.spec.ts --project=chromium",
     "test:visual:update": "npm test -- tests/06-theme-visual.spec.ts --project=chromium --update-snapshots",

--- a/tests/integration/scripts/check-e2e-tiering-lib.mjs
+++ b/tests/integration/scripts/check-e2e-tiering-lib.mjs
@@ -1,0 +1,213 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+const MIN_STABLE_SPEC_FILES = 10;
+const MAX_OUTPUT_BYTES = 64 * 1024 * 1024;
+
+function listSpecFiles(testsRoot) {
+  const specs = [];
+  function walk(directory, relativeDirectory = '') {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isDirectory()) {
+        walk(
+          path.join(directory, entry.name),
+          `${relativeDirectory}${entry.name}/`,
+        );
+      } else if (entry.name.endsWith('.spec.ts')) {
+        specs.push(`${relativeDirectory}${entry.name}`);
+      }
+    }
+  }
+  walk(testsRoot);
+  return specs.sort();
+}
+
+function duplicates(values) {
+  const seen = new Set();
+  return values.filter((value) => {
+    if (seen.has(value)) return true;
+    seen.add(value);
+    return false;
+  });
+}
+
+function difference(left, right) {
+  return new Set([...left].filter((value) => !right.has(value)));
+}
+
+function sameSet(actual, expected, label, errors) {
+  const missing = difference(expected, actual);
+  const extra = difference(actual, expected);
+  if (missing.size)
+    errors.push(`${label} is missing: ${[...missing].join(', ')}`);
+  if (extra.size)
+    errors.push(`${label} has unexpected entries: ${[...extra].join(', ')}`);
+}
+
+function ledgerFiles(values, label, allFiles, errors) {
+  const badFormat = values.filter(
+    (value) => !/^\*\*\/.+\.spec\.ts$/.test(value),
+  );
+  if (badFormat.length)
+    errors.push(`${label} has invalid entries: ${badFormat.join(', ')}`);
+
+  const duplicateValues = duplicates(values);
+  if (duplicateValues.length)
+    errors.push(`${label} has duplicates: ${duplicateValues.join(', ')}`);
+
+  const sortedValues = [...values].sort();
+  if (values.some((value, index) => value !== sortedValues[index])) {
+    errors.push(`${label} must be sorted`);
+  }
+
+  const files = new Set(values.map((value) => value.replace(/^\*\*\//, '')));
+  const unknown = [...files].filter((value) => !allFiles.has(value));
+  if (unknown.length)
+    errors.push(`${label} has unknown specs: ${unknown.join(', ')}`);
+  return files;
+}
+
+export function listPlaywrightTests({
+  integrationRoot,
+  tier,
+  spawn = spawnSync,
+}) {
+  const playwrightCli = path.join(
+    integrationRoot,
+    'node_modules',
+    'playwright',
+    'cli.js',
+  );
+  if (!fs.existsSync(playwrightCli)) {
+    throw new Error(
+      'Pinned Playwright CLI is not installed; run npm ci before this check',
+    );
+  }
+  const env = { ...process.env };
+  if (tier) env.PULSE_E2E_TIER = tier;
+  else delete env.PULSE_E2E_TIER;
+
+  const result = spawn(process.execPath, [playwrightCli, 'test', '--list'], {
+    cwd: integrationRoot,
+    env,
+    encoding: 'utf8',
+    maxBuffer: MAX_OUTPUT_BYTES,
+    shell: false,
+  });
+  const label = tier || 'all';
+  if (result.error) {
+    throw new Error(
+      `Could not launch pinned Playwright CLI for ${label} tier: ${result.error.message}`,
+    );
+  }
+  if (result.signal) {
+    throw new Error(
+      `Pinned Playwright CLI was signaled for ${label} tier: ${result.signal}`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Pinned Playwright CLI --list failed for ${label} tier:\n${result.stderr || result.stdout}`,
+    );
+  }
+
+  const tests = new Map();
+  for (const rawLine of result.stdout.split('\n')) {
+    const line = rawLine.replace(/\x1b\[[0-9;]*m/g, '');
+    const match = line.match(
+      /^\s*\[([^\]]+)\] › ((.+?\.spec\.ts):\d+:\d+ › .+)$/,
+    );
+    if (!match) continue;
+    const testPath = match[3].replaceAll('\\', '/');
+    const key = `[${match[1]}] › ${testPath}${match[2].slice(match[3].length)}`;
+    if (tests.has(key))
+      throw new Error(`Playwright listed a duplicate test: ${key}`);
+    tests.set(key, testPath);
+  }
+  return tests;
+}
+
+export async function validateE2ETiering({ integrationRoot }) {
+  const ledger = await import(
+    `${pathToFileURL(path.join(integrationRoot, 'e2e-tiering.mjs')).href}?${Date.now()}`
+  );
+  const errors = [];
+  const allFiles = new Set(listSpecFiles(path.join(integrationRoot, 'tests')));
+  const probationFiles = ledgerFiles(
+    ledger.PROBATION_SPECS,
+    'PROBATION_SPECS',
+    allFiles,
+    errors,
+  );
+  const quarantineFiles = ledgerFiles(
+    ledger.QUARANTINED_SPECS,
+    'QUARANTINED_SPECS',
+    allFiles,
+    errors,
+  );
+  const overlap = [...probationFiles].filter((value) =>
+    quarantineFiles.has(value),
+  );
+  if (overlap.length)
+    errors.push(`Probation/quarantine overlap: ${overlap.join(', ')}`);
+
+  const allTests = listPlaywrightTests({ integrationRoot, tier: null });
+  const stableTests = listPlaywrightTests({ integrationRoot, tier: 'stable' });
+  const probationTests = listPlaywrightTests({
+    integrationRoot,
+    tier: 'probation',
+  });
+  const allKeys = new Set(allTests.keys());
+  const stableKeys = new Set(stableTests.keys());
+  const probationKeys = new Set(probationTests.keys());
+
+  const instanceOverlap = [...stableKeys].filter((key) =>
+    probationKeys.has(key),
+  );
+  if (instanceOverlap.length)
+    errors.push(`Stable/probation test overlap: ${instanceOverlap.join(', ')}`);
+  sameSet(
+    new Set([...stableKeys, ...probationKeys]),
+    allKeys,
+    'Stable + probation tests',
+    errors,
+  );
+
+  const listedAllFiles = new Set(allTests.values());
+  const listedStableFiles = new Set(stableTests.values());
+  const listedProbationFiles = new Set(probationTests.values());
+  const expectedAllFiles = difference(allFiles, quarantineFiles);
+  const expectedStableFiles = difference(expectedAllFiles, probationFiles);
+  sameSet(listedAllFiles, expectedAllFiles, 'All-tier spec files', errors);
+  sameSet(
+    listedStableFiles,
+    expectedStableFiles,
+    'Stable-tier spec files',
+    errors,
+  );
+  sameSet(
+    listedProbationFiles,
+    probationFiles,
+    'Probation-tier spec files',
+    errors,
+  );
+
+  if (listedStableFiles.size < MIN_STABLE_SPEC_FILES) {
+    errors.push(
+      `Stable tier has ${listedStableFiles.size} spec files; the signal floor is ${MIN_STABLE_SPEC_FILES}`,
+    );
+  }
+
+  return {
+    allFiles,
+    allTests,
+    errors,
+    listedProbationFiles,
+    listedStableFiles,
+    probationTests,
+    quarantineFiles,
+    stableTests,
+  };
+}

--- a/tests/integration/scripts/check-e2e-tiering.mjs
+++ b/tests/integration/scripts/check-e2e-tiering.mjs
@@ -1,149 +1,27 @@
 #!/usr/bin/env node
 
-import fs from 'node:fs';
-import path from 'node:path';
-import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 
-import {
-  PROBATION_SPECS,
-  QUARANTINED_SPECS,
-} from '../e2e-tiering.mjs';
+import { validateE2ETiering } from './check-e2e-tiering-lib.mjs';
 
-const integrationRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
-const testsRoot = path.join(integrationRoot, 'tests');
-const playwrightBin = path.join(integrationRoot, 'node_modules', '.bin', 'playwright');
-const MIN_STABLE_SPEC_FILES = 10;
-
-function listSpecFiles() {
-  const specs = [];
-  function walk(directory, relativeDirectory = '') {
-    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
-        walk(path.join(directory, entry.name), `${relativeDirectory}${entry.name}/`);
-      } else if (entry.name.endsWith('.spec.ts')) {
-        specs.push(`${relativeDirectory}${entry.name}`);
-      }
-    }
-  }
-  walk(testsRoot);
-  return specs.sort();
-}
-
-function duplicates(values) {
-  const seen = new Set();
-  return values.filter((value) => {
-    if (seen.has(value)) return true;
-    seen.add(value);
-    return false;
-  });
-}
-
-function ledgerFiles(values, label, allFiles, errors) {
-  const badFormat = values.filter((value) => !/^\*\*\/.+\.spec\.ts$/.test(value));
-  if (badFormat.length) errors.push(`${label} has invalid entries: ${badFormat.join(', ')}`);
-
-  const duplicateValues = duplicates(values);
-  if (duplicateValues.length) errors.push(`${label} has duplicates: ${duplicateValues.join(', ')}`);
-
-  const sortedValues = [...values].sort();
-  if (values.some((value, index) => value !== sortedValues[index])) {
-    errors.push(`${label} must be sorted`);
-  }
-
-  const files = new Set(values.map((value) => value.replace(/^\*\*\//, '')));
-  const unknown = [...files].filter((value) => !allFiles.has(value));
-  if (unknown.length) errors.push(`${label} has unknown specs: ${unknown.join(', ')}`);
-  return files;
-}
-
-function listPlaywrightTests(tier) {
-  if (!fs.existsSync(playwrightBin)) {
-    throw new Error('Playwright is not installed; run npm ci before this check');
-  }
-  const env = { ...process.env };
-  if (tier) env.PULSE_E2E_TIER = tier;
-  else delete env.PULSE_E2E_TIER;
-
-  const result = spawnSync(playwrightBin, ['test', '--list'], {
-    cwd: integrationRoot,
-    env,
-    encoding: 'utf8',
-    maxBuffer: 64 * 1024 * 1024,
-  });
-  if (result.status !== 0) {
-    throw new Error(
-      `Playwright --list failed for ${tier || 'all'} tier:\n${result.stderr || result.stdout}`,
-    );
-  }
-
-  const tests = new Map();
-  for (const rawLine of result.stdout.split('\n')) {
-    const line = rawLine.replace(/\x1b\[[0-9;]*m/g, '');
-    const match = line.match(/^\s*\[([^\]]+)\] › ((.+?\.spec\.ts):\d+:\d+ › .+)$/);
-    if (!match) continue;
-    const key = `[${match[1]}] › ${match[2]}`;
-    if (tests.has(key)) throw new Error(`Playwright listed a duplicate test: ${key}`);
-    tests.set(key, match[3]);
-  }
-  return tests;
-}
-
-function difference(left, right) {
-  return new Set([...left].filter((value) => !right.has(value)));
-}
-
-function sameSet(actual, expected, label, errors) {
-  const missing = difference(expected, actual);
-  const extra = difference(actual, expected);
-  if (missing.size) errors.push(`${label} is missing: ${[...missing].join(', ')}`);
-  if (extra.size) errors.push(`${label} has unexpected entries: ${[...extra].join(', ')}`);
-}
-
-const errors = [];
-const allFiles = new Set(listSpecFiles());
-const probationFiles = ledgerFiles(PROBATION_SPECS, 'PROBATION_SPECS', allFiles, errors);
-const quarantineFiles = ledgerFiles(QUARANTINED_SPECS, 'QUARANTINED_SPECS', allFiles, errors);
-const overlap = [...probationFiles].filter((value) => quarantineFiles.has(value));
-if (overlap.length) errors.push(`Probation/quarantine overlap: ${overlap.join(', ')}`);
-
-const allTests = listPlaywrightTests(null);
-const stableTests = listPlaywrightTests('stable');
-const probationTests = listPlaywrightTests('probation');
-const allKeys = new Set(allTests.keys());
-const stableKeys = new Set(stableTests.keys());
-const probationKeys = new Set(probationTests.keys());
-
-const instanceOverlap = [...stableKeys].filter((key) => probationKeys.has(key));
-if (instanceOverlap.length) errors.push(`Stable/probation test overlap: ${instanceOverlap.join(', ')}`);
-sameSet(new Set([...stableKeys, ...probationKeys]), allKeys, 'Stable + probation tests', errors);
-
-const listedAllFiles = new Set(allTests.values());
-const listedStableFiles = new Set(stableTests.values());
-const listedProbationFiles = new Set(probationTests.values());
-const expectedAllFiles = difference(allFiles, quarantineFiles);
-const expectedStableFiles = difference(expectedAllFiles, probationFiles);
-sameSet(listedAllFiles, expectedAllFiles, 'All-tier spec files', errors);
-sameSet(listedStableFiles, expectedStableFiles, 'Stable-tier spec files', errors);
-sameSet(listedProbationFiles, probationFiles, 'Probation-tier spec files', errors);
-
-if (listedStableFiles.size < MIN_STABLE_SPEC_FILES) {
-  errors.push(
-    `Stable tier has ${listedStableFiles.size} spec files; the signal floor is ${MIN_STABLE_SPEC_FILES}`,
-  );
-}
-
-if (errors.length) {
+const integrationRoot = path.resolve(
+  fileURLToPath(new URL('..', import.meta.url)),
+);
+const result = await validateE2ETiering({ integrationRoot });
+if (result.errors.length) {
   console.error('E2E tier selection validation failed:');
-  for (const error of errors) console.error(`- ${error}`);
+  for (const error of result.errors) console.error(`- ${error}`);
   process.exit(1);
 }
 
 console.log('E2E tier selection validation passed');
-console.log(`  spec_files: ${allFiles.size}`);
-console.log(`  stable_spec_files: ${listedStableFiles.size}`);
-console.log(`  probation_spec_files: ${listedProbationFiles.size}`);
-console.log(`  quarantined_spec_files: ${quarantineFiles.size}`);
-console.log(`  test_project_instances: ${allTests.size}`);
-console.log(`  stable_test_project_instances: ${stableTests.size}`);
-console.log(`  probation_test_project_instances: ${probationTests.size}`);
+console.log(`  spec_files: ${result.allFiles.size}`);
+console.log(`  stable_spec_files: ${result.listedStableFiles.size}`);
+console.log(`  probation_spec_files: ${result.listedProbationFiles.size}`);
+console.log(`  quarantined_spec_files: ${result.quarantineFiles.size}`);
+console.log(`  test_project_instances: ${result.allTests.size}`);
+console.log(`  stable_test_project_instances: ${result.stableTests.size}`);
+console.log(
+  `  probation_test_project_instances: ${result.probationTests.size}`,
+);

--- a/tests/integration/scripts/check-e2e-tiering.test.mjs
+++ b/tests/integration/scripts/check-e2e-tiering.test.mjs
@@ -1,0 +1,296 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  listPlaywrightTests,
+  validateE2ETiering,
+} from './check-e2e-tiering-lib.mjs';
+
+const canonicalLedger = path.resolve(
+  fileURLToPath(new URL('../e2e-tiering.mjs', import.meta.url)),
+);
+
+const cliSource = `
+import fs from 'node:fs';
+
+const mode = process.env.PULSE_TIER_SMOKE_MODE;
+if (mode === 'nonzero') {
+  console.error('fixture Playwright failure');
+  process.exit(23);
+}
+if (mode === 'signal') {
+  console.error('fixture Playwright termination');
+  process.kill(process.pid, 'SIGTERM');
+}
+
+const marker = process.env.PULSE_TIER_SMOKE_MARKER;
+if (marker) {
+  fs.appendFileSync(marker, JSON.stringify({ argv: process.argv, execPath: process.execPath }) + '\\n');
+}
+
+const tier = process.env.PULSE_E2E_TIER;
+const files = fs.readdirSync('tests').filter((name) => name.endsWith('.spec.ts')).sort();
+const selected = tier === 'probation' ? [] : files;
+if (mode === 'omit-stable' && tier === 'stable') selected.pop();
+for (const file of selected) console.log('[chromium] › ' + file + ':1:1 › fixture test');
+`;
+
+async function createFixture({
+  fileCount = 10,
+  ledger = 'export const PROBATION_SPECS = [];\nexport const QUARANTINED_SPECS = [];\n',
+} = {}) {
+  const integrationRoot = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'pulse tier checker space-'),
+  );
+  await fs.mkdir(path.join(integrationRoot, 'tests'), { recursive: true });
+  await fs.mkdir(path.join(integrationRoot, 'node_modules', 'playwright'), {
+    recursive: true,
+  });
+  await fs.writeFile(path.join(integrationRoot, 'e2e-tiering.mjs'), ledger);
+  await fs.writeFile(
+    path.join(integrationRoot, 'node_modules', 'playwright', 'cli.js'),
+    cliSource,
+  );
+  await Promise.all(
+    Array.from({ length: fileCount }, (_, index) =>
+      fs.writeFile(
+        path.join(
+          integrationRoot,
+          'tests',
+          `fixture-${String(index).padStart(2, '0')}.spec.ts`,
+        ),
+        '',
+      ),
+    ),
+  );
+  return integrationRoot;
+}
+
+async function removeFixture(integrationRoot) {
+  await fs.rm(integrationRoot, { recursive: true, force: true });
+}
+
+test('uses Node to launch the pinned CLI from an integration path containing spaces', async (t) => {
+  const integrationRoot = await createFixture();
+  const marker = path.join(integrationRoot, 'launcher.jsonl');
+  const previousMarker = process.env.PULSE_TIER_SMOKE_MARKER;
+  process.env.PULSE_TIER_SMOKE_MARKER = marker;
+  t.after(async () => {
+    if (previousMarker === undefined)
+      delete process.env.PULSE_TIER_SMOKE_MARKER;
+    else process.env.PULSE_TIER_SMOKE_MARKER = previousMarker;
+    await removeFixture(integrationRoot);
+  });
+
+  const result = await validateE2ETiering({ integrationRoot });
+  assert.deepEqual(result.errors, []);
+  assert.equal(result.allFiles.size, 10);
+  assert.equal(result.stableTests.size, 10);
+
+  const launches = (await fs.readFile(marker, 'utf8'))
+    .trim()
+    .split('\n')
+    .map((line) => JSON.parse(line));
+  assert.equal(launches.length, 3);
+  for (const launch of launches) {
+    assert.equal(launch.execPath, process.execPath);
+    assert.deepEqual(launch.argv.slice(1), [
+      path.join(integrationRoot, 'node_modules', 'playwright', 'cli.js'),
+      'test',
+      '--list',
+    ]);
+  }
+});
+
+test('reports malformed fixture ledgers without changing the canonical ledger', async (t) => {
+  const integrationRoot = await createFixture({
+    ledger:
+      "export const PROBATION_SPECS = ['not-a-glob'];\nexport const QUARANTINED_SPECS = [];\n",
+  });
+  const before = await fs.readFile(canonicalLedger, 'utf8');
+  t.after(async () => removeFixture(integrationRoot));
+
+  const result = await validateE2ETiering({ integrationRoot });
+  assert.match(
+    result.errors.join('\n'),
+    /PROBATION_SPECS has invalid entries: not-a-glob/,
+  );
+  assert.equal(await fs.readFile(canonicalLedger, 'utf8'), before);
+});
+
+test('retains duplicate, overlap, unknown, sorting, split, and stable-floor ledger rejection', async (t) => {
+  const cases = [
+    {
+      ledger:
+        "export const PROBATION_SPECS = ['**/fixture-00.spec.ts', '**/fixture-00.spec.ts'];\nexport const QUARANTINED_SPECS = [];\n",
+      expected: /PROBATION_SPECS has duplicates: \*\*\/fixture-00.spec.ts/,
+      name: 'duplicate',
+    },
+    {
+      ledger:
+        "export const PROBATION_SPECS = ['**/fixture-00.spec.ts'];\nexport const QUARANTINED_SPECS = ['**/fixture-00.spec.ts'];\n",
+      expected: /Probation\/quarantine overlap: fixture-00.spec.ts/,
+      name: 'overlap',
+    },
+    {
+      ledger:
+        "export const PROBATION_SPECS = ['**/missing.spec.ts'];\nexport const QUARANTINED_SPECS = [];\n",
+      expected: /PROBATION_SPECS has unknown specs: missing.spec.ts/,
+      name: 'unknown',
+    },
+    {
+      ledger:
+        "export const PROBATION_SPECS = ['**/fixture-09.spec.ts', '**/fixture-00.spec.ts'];\nexport const QUARANTINED_SPECS = [];\n",
+      expected: /PROBATION_SPECS must be sorted/,
+      name: 'unsorted',
+    },
+  ];
+  const canonicalBefore = await fs.readFile(canonicalLedger, 'utf8');
+  const roots = [];
+  t.after(async () => {
+    await Promise.all(roots.map(removeFixture));
+    assert.equal(await fs.readFile(canonicalLedger, 'utf8'), canonicalBefore);
+  });
+
+  for (const fixtureCase of cases) {
+    const integrationRoot = await createFixture({ ledger: fixtureCase.ledger });
+    roots.push(integrationRoot);
+    const result = await validateE2ETiering({ integrationRoot });
+    assert.match(
+      result.errors.join('\n'),
+      fixtureCase.expected,
+      fixtureCase.name,
+    );
+  }
+
+  const previousMode = process.env.PULSE_TIER_SMOKE_MODE;
+  process.env.PULSE_TIER_SMOKE_MODE = 'omit-stable';
+  const splitRoot = await createFixture();
+  roots.push(splitRoot);
+  const splitResult = await validateE2ETiering({ integrationRoot: splitRoot });
+  assert.match(
+    splitResult.errors.join('\n'),
+    /Stable \+ probation tests is missing/,
+  );
+  if (previousMode === undefined) delete process.env.PULSE_TIER_SMOKE_MODE;
+  else process.env.PULSE_TIER_SMOKE_MODE = previousMode;
+
+  const floorRoot = await createFixture({ fileCount: 9 });
+  roots.push(floorRoot);
+  const floorResult = await validateE2ETiering({ integrationRoot: floorRoot });
+  assert.match(
+    floorResult.errors.join('\n'),
+    /Stable tier has 9 spec files; the signal floor is 10/,
+  );
+});
+
+test('fails closed for a missing CLI and unsuccessful child processes', async (t) => {
+  const integrationRoot = await createFixture();
+  t.after(async () => removeFixture(integrationRoot));
+
+  await fs.rm(
+    path.join(integrationRoot, 'node_modules', 'playwright', 'cli.js'),
+  );
+  assert.throws(
+    () => listPlaywrightTests({ integrationRoot, tier: null }),
+    /Pinned Playwright CLI is not installed/,
+  );
+
+  await fs.writeFile(
+    path.join(integrationRoot, 'node_modules', 'playwright', 'cli.js'),
+    cliSource,
+  );
+  const calls = [];
+  assert.throws(
+    () =>
+      listPlaywrightTests({
+        integrationRoot,
+        tier: 'stable',
+        spawn: (command, args, options) => {
+          calls.push({ args, command, options });
+          return { error: new Error('launch blocked') };
+        },
+      }),
+    /Could not launch pinned Playwright CLI for stable tier: launch blocked/,
+  );
+  assert.equal(calls[0].command, process.execPath);
+  assert.deepEqual(calls[0].args.slice(1), ['test', '--list']);
+  assert.equal(calls[0].options.shell, false);
+
+  const windowsListedTests = listPlaywrightTests({
+    integrationRoot,
+    tier: null,
+    spawn: () => ({
+      status: 0,
+      stdout:
+        '  [chromium] › journeys\\fixture.spec.ts:1:1 › fixture \\ title\n',
+    }),
+  });
+  assert.deepEqual(
+    [...windowsListedTests.values()],
+    ['journeys/fixture.spec.ts'],
+  );
+  assert.deepEqual(
+    [...windowsListedTests.keys()],
+    ['[chromium] › journeys/fixture.spec.ts:1:1 › fixture \\ title'],
+  );
+
+  assert.throws(
+    () =>
+      listPlaywrightTests({
+        integrationRoot,
+        tier: null,
+        spawn: () => ({ signal: 'SIGTERM' }),
+      }),
+    /Pinned Playwright CLI was signaled for all tier: SIGTERM/,
+  );
+  assert.throws(
+    () =>
+      listPlaywrightTests({
+        integrationRoot,
+        tier: null,
+        spawn: () => ({ status: 23, stderr: 'fixture Playwright failure' }),
+      }),
+    /Pinned Playwright CLI --list failed for all tier:\nfixture Playwright failure/,
+  );
+});
+
+test('fails closed when the pinned CLI exits nonzero', async (t) => {
+  const integrationRoot = await createFixture();
+  const previousMode = process.env.PULSE_TIER_SMOKE_MODE;
+  process.env.PULSE_TIER_SMOKE_MODE = 'nonzero';
+  t.after(async () => {
+    if (previousMode === undefined) delete process.env.PULSE_TIER_SMOKE_MODE;
+    else process.env.PULSE_TIER_SMOKE_MODE = previousMode;
+    await removeFixture(integrationRoot);
+  });
+
+  assert.throws(
+    () => listPlaywrightTests({ integrationRoot, tier: null }),
+    /Pinned Playwright CLI --list failed for all tier:\nfixture Playwright failure/,
+  );
+});
+
+test('fails closed when the pinned CLI is signaled', async (t) => {
+  const integrationRoot = await createFixture();
+  const previousMode = process.env.PULSE_TIER_SMOKE_MODE;
+  process.env.PULSE_TIER_SMOKE_MODE = 'signal';
+  t.after(async () => {
+    if (previousMode === undefined) delete process.env.PULSE_TIER_SMOKE_MODE;
+    else process.env.PULSE_TIER_SMOKE_MODE = previousMode;
+    await removeFixture(integrationRoot);
+  });
+
+  const expected =
+    process.platform === 'win32'
+      ? /Pinned Playwright CLI --list failed for all tier:\nfixture Playwright termination/
+      : /Pinned Playwright CLI was signaled for all tier: SIGTERM/;
+  assert.throws(
+    () => listPlaywrightTests({ integrationRoot, tier: null }),
+    expected,
+  );
+});


### PR DESCRIPTION
## Summary
- launch the lockfile-pinned Playwright JavaScript CLI via `process.execPath` with fixed arguments and `shell: false`
- add isolated launcher and malformed-ledger smoke coverage, including all retained validation branches
- exercise the documented checker after `npm ci` on native Ubuntu and Windows runners

## Validation
- `cd tests/integration && npm run test:check:e2e-tiers`
- `cd tests/integration && npm run check:e2e-tiers`
- `git diff --check`

Accounting remains 95 total files: 50 stable, 42 probation, 3 quarantined; 826/291/535 project instances.