### PR TITLE
Restore canonical and Windows release verification

### DIFF
--- a/docs/release-control/v6/internal/subsystems/performance-and-scalability.md
+++ b/docs/release-control/v6/internal/subsystems/performance-and-scalability.md
@@ -1692,6 +1692,20 @@ workload hot path must also tolerate transient async route/data gaps by
 treating missing filtered-workload collections as empty until the route and
 resource snapshots converge, rather than crashing Workloads between sync
 phases.
+Platform-owned Workloads surfaces must also normalize their inventory before
+deduplication and downstream derivation. `useWorkloadsState.ts` calls
+`selectVisibleWorkloadInventory` once to apply only the owning page's forced
+platform and explicitly excluded workload types; ordinary user-selected
+status, search, node, namespace, and runtime filters remain in the later filter
+pipeline. The normalized inventory is the shared input for filter options,
+summary counts, empty-state availability, and table rows, so an off-platform
+degraded guest cannot inflate a platform page's Attention count or produce a
+filter state whose table can never show that guest. This boundary must remain
+a single linear selector pass with an identity-preserving fast path when no
+page-owned scope applies, rather than adding per-card or per-option scans.
+`workloadSelectors.test.ts` verifies the no-scope identity path, workload-type
+exclusion, forced-platform matching, and the cross-platform degraded-count
+regression.
 That same workload hot path also owns the split between canonical
 app-container routing and Docker-only actions. `frontend-modern/src/hooks/useWorkloads.ts`,
 `frontend-modern/src/components/Workloads/workloadTopology.ts`, and

--- a/frontend-modern/src/components/Workloads/__tests__/workloadSelectors.test.ts
+++ b/frontend-modern/src/components/Workloads/__tests__/workloadSelectors.test.ts
@@ -713,9 +713,7 @@ describe('workloadSelectors', () => {
 
     it('returns the input list when no scope or exclusions apply', () => {
       const guests = [makeGuest(1), makeGuest(2)];
-      expect(
-        selectVisibleWorkloadInventory({ guests, excludedTypes: noExclusions }),
-      ).toBe(guests);
+      expect(selectVisibleWorkloadInventory({ guests, excludedTypes: noExclusions })).toBe(guests);
       expect(
         selectVisibleWorkloadInventory({
           guests,

--- a/internal/dockeragent/registry_credentials_test.go
+++ b/internal/dockeragent/registry_credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,11 @@ func basicAuthValue(username, secret string) string {
 }
 
 func newTestCredentialStore(files map[string]string, env map[string]string) *dockerConfigCredentials {
+	cleanFiles := make(map[string]string, len(files))
+	for path, content := range files {
+		cleanFiles[filepath.Clean(path)] = content
+	}
+
 	c := &dockerConfigCredentials{
 		logger: zerolog.Nop(),
 		cache:  map[string]credentialCacheEntry{},
@@ -46,7 +52,7 @@ func newTestCredentialStore(files map[string]string, env map[string]string) *doc
 			return "", errors.New("no home")
 		},
 		readFile: func(path string) ([]byte, error) {
-			if content, ok := files[path]; ok {
+			if content, ok := cleanFiles[filepath.Clean(path)]; ok {
 				return []byte(content), nil
 			}
 			return nil, os.ErrNotExist
@@ -272,7 +278,7 @@ func TestDockerConfigCredentials_CacheAvoidsRepeatResolution(t *testing.T) {
 	store := newTestCredentialStore(nil, map[string]string{"HOME": "/home/agent"})
 	store.readFile = func(path string) ([]byte, error) {
 		reads++
-		if path == "/home/agent/.docker/config.json" {
+		if filepath.Clean(path) == filepath.Clean("/home/agent/.docker/config.json") {
 			return []byte(fmt.Sprintf(`{"auths":{"registry.example.com":{"auth":%q}}}`, auth)), nil
 		}
 		return nil, os.ErrNotExist

--- a/internal/hostagent/privilege_test.go
+++ b/internal/hostagent/privilege_test.go
@@ -37,6 +37,9 @@ func TestCollectPrivilegeStatusReportsHelperOverrides(t *testing.T) {
 
 func TestResolvePctPathHonorsAbsoluteOverride(t *testing.T) {
 	configuredPath := filepath.Join(t.TempDir(), "pct-helper")
+	if !filepath.IsAbs(configuredPath) {
+		t.Fatalf("native test override = %q, want absolute path", configuredPath)
+	}
 	t.Setenv("PULSE_PCT_PATH", configuredPath)
 
 	resolved, err := resolvePctPath(func(string) (string, error) {

--- a/internal/hostagent/privilege_test.go
+++ b/internal/hostagent/privilege_test.go
@@ -2,6 +2,7 @@ package hostagent
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -35,7 +36,8 @@ func TestCollectPrivilegeStatusReportsHelperOverrides(t *testing.T) {
 }
 
 func TestResolvePctPathHonorsAbsoluteOverride(t *testing.T) {
-	t.Setenv("PULSE_PCT_PATH", "/usr/local/lib/pulse-agent/pct-helper")
+	configuredPath := filepath.Join(t.TempDir(), "pct-helper")
+	t.Setenv("PULSE_PCT_PATH", configuredPath)
 
 	resolved, err := resolvePctPath(func(string) (string, error) {
 		t.Fatal("lookPath must not be consulted when the override is set")
@@ -44,8 +46,8 @@ func TestResolvePctPathHonorsAbsoluteOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolvePctPath: %v", err)
 	}
-	if resolved != "/usr/local/lib/pulse-agent/pct-helper" {
-		t.Fatalf("resolved = %q", resolved)
+	if resolved != configuredPath {
+		t.Fatalf("resolved = %q, want %q", resolved, configuredPath)
 	}
 }
 

--- a/scripts/release_control/release_promotion_policy_test.py
+++ b/scripts/release_control/release_promotion_policy_test.py
@@ -1068,7 +1068,10 @@ class ReleasePromotionPolicyTest(unittest.TestCase):
                 release_notes = read(release_notes_path)
                 changelog = read(changelog_path)
 
-                self.assertIn("current v6 support release candidate packet", release_index)
+                self.assertIn(
+                    "current v6 support release candidate packet",
+                    normalize_ws(release_index),
+                )
                 self.assertIn(release_notes_path, release_index)
                 self.assertIn(changelog_path, release_index)
                 self.assertIn(f"Pulse v{current_version} Release Notes", release_notes)


### PR DESCRIPTION
## Summary

- make the PCT helper override regression test use a native absolute path on every runner
- document the pre-dedupe Workloads inventory boundary in the canonical performance contract
- retain runtime path validation and canonical governance protections unchanged

## Incident evidence

Unified Agent Native Verification failed only on Windows because the test supplied a POSIX absolute path, which `filepath.IsAbs` correctly rejects on Windows. The runtime implementation remains unchanged.

Canonical Governance identified the platform-scoped Workloads selector change as missing a substantive performance-and-scalability contract update. The new text documents the exact forced-platform/excluded-type boundary, downstream consumers, identity fast path, and linear-pass constraint.

## Validation

- `go test ./internal/hostagent -run TestResolvePctPathHonorsAbsoluteOverride -count=1`
- Windows amd64 cross-compile of `./internal/hostagent`
- `npm test -- --run src/components/Workloads/__tests__/workloadSelectors.test.ts` (30 tests)
- `python3 scripts/release_control/canonical_completion_guard_test.py` (125 tests)
- `python3 scripts/release_control/governance_stage_guard_test.py` (4 tests)
- canonical completion guard passes both the recovery-only range and the combined original-change-plus-recovery range

Rollback anchor: `86d0af497910625126e28cab1c5d0515e01c994d`.