### PR TITLE
Recover release verification with exact E2E failure evidence

### DIFF
--- a/docs/release-control/v6/internal/subsystems/performance-and-scalability.md
+++ b/docs/release-control/v6/internal/subsystems/performance-and-scalability.md
@@ -1692,6 +1692,20 @@ workload hot path must also tolerate transient async route/data gaps by
 treating missing filtered-workload collections as empty until the route and
 resource snapshots converge, rather than crashing Workloads between sync
 phases.
+Platform-owned Workloads surfaces must also normalize their inventory before
+deduplication and downstream derivation. `useWorkloadsState.ts` calls
+`selectVisibleWorkloadInventory` once to apply only the owning page's forced
+platform and explicitly excluded workload types; ordinary user-selected
+status, search, node, namespace, and runtime filters remain in the later filter
+pipeline. The normalized inventory is the shared input for filter options,
+summary counts, empty-state availability, and table rows, so an off-platform
+degraded guest cannot inflate a platform page's Attention count or produce a
+filter state whose table can never show that guest. This boundary must remain
+a single linear selector pass with an identity-preserving fast path when no
+page-owned scope applies, rather than adding per-card or per-option scans.
+`workloadSelectors.test.ts` verifies the no-scope identity path, workload-type
+exclusion, forced-platform matching, and the cross-platform degraded-count
+regression.
 That same workload hot path also owns the split between canonical
 app-container routing and Docker-only actions. `frontend-modern/src/hooks/useWorkloads.ts`,
 `frontend-modern/src/components/Workloads/workloadTopology.ts`, and

--- a/internal/dockeragent/registry_credentials_test.go
+++ b/internal/dockeragent/registry_credentials_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,11 @@ func basicAuthValue(username, secret string) string {
 }
 
 func newTestCredentialStore(files map[string]string, env map[string]string) *dockerConfigCredentials {
+	cleanFiles := make(map[string]string, len(files))
+	for path, content := range files {
+		cleanFiles[filepath.Clean(path)] = content
+	}
+
 	c := &dockerConfigCredentials{
 		logger: zerolog.Nop(),
 		cache:  map[string]credentialCacheEntry{},
@@ -46,7 +52,7 @@ func newTestCredentialStore(files map[string]string, env map[string]string) *doc
 			return "", errors.New("no home")
 		},
 		readFile: func(path string) ([]byte, error) {
-			if content, ok := files[path]; ok {
+			if content, ok := cleanFiles[filepath.Clean(path)]; ok {
 				return []byte(content), nil
 			}
 			return nil, os.ErrNotExist
@@ -272,7 +278,7 @@ func TestDockerConfigCredentials_CacheAvoidsRepeatResolution(t *testing.T) {
 	store := newTestCredentialStore(nil, map[string]string{"HOME": "/home/agent"})
 	store.readFile = func(path string) ([]byte, error) {
 		reads++
-		if path == "/home/agent/.docker/config.json" {
+		if filepath.Clean(path) == filepath.Clean("/home/agent/.docker/config.json") {
 			return []byte(fmt.Sprintf(`{"auths":{"registry.example.com":{"auth":%q}}}`, auth)), nil
 		}
 		return nil, os.ErrNotExist

--- a/internal/hostagent/privilege_test.go
+++ b/internal/hostagent/privilege_test.go
@@ -2,6 +2,7 @@ package hostagent
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -35,7 +36,11 @@ func TestCollectPrivilegeStatusReportsHelperOverrides(t *testing.T) {
 }
 
 func TestResolvePctPathHonorsAbsoluteOverride(t *testing.T) {
-	t.Setenv("PULSE_PCT_PATH", "/usr/local/lib/pulse-agent/pct-helper")
+	configuredPath := filepath.Join(t.TempDir(), "pct-helper")
+	if !filepath.IsAbs(configuredPath) {
+		t.Fatalf("native test override = %q, want absolute path", configuredPath)
+	}
+	t.Setenv("PULSE_PCT_PATH", configuredPath)
 
 	resolved, err := resolvePctPath(func(string) (string, error) {
 		t.Fatal("lookPath must not be consulted when the override is set")
@@ -44,8 +49,8 @@ func TestResolvePctPathHonorsAbsoluteOverride(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolvePctPath: %v", err)
 	}
-	if resolved != "/usr/local/lib/pulse-agent/pct-helper" {
-		t.Fatalf("resolved = %q", resolved)
+	if resolved != configuredPath {
+		t.Fatalf("resolved = %q, want %q", resolved, configuredPath)
 	}
 }
 

--- a/scripts/release_control/release_promotion_policy_test.py
+++ b/scripts/release_control/release_promotion_policy_test.py
@@ -1068,7 +1068,10 @@ class ReleasePromotionPolicyTest(unittest.TestCase):
                 release_notes = read(release_notes_path)
                 changelog = read(changelog_path)
 
-                self.assertIn("current v6 support release candidate packet", release_index)
+                self.assertIn(
+                    "current v6 support release candidate packet",
+                    normalize_ws(release_index),
+                )
                 self.assertIn(release_notes_path, release_index)
                 self.assertIn(changelog_path, release_index)
                 self.assertIn(f"Pulse v{current_version} Release Notes", release_notes)

--- a/tests/integration/playwright.config.ts
+++ b/tests/integration/playwright.config.ts
@@ -1,34 +1,31 @@
-import { defineConfig, devices } from '@playwright/test';
-import {
-  PROBATION_SPECS,
-  QUARANTINED_SPECS,
-} from './e2e-tiering.mjs';
-import { preferredBrowserBaseURL } from './tests/runtime-defaults';
+import { defineConfig, devices } from "@playwright/test";
+import { PROBATION_SPECS, QUARANTINED_SPECS } from "./e2e-tiering.mjs";
+import { preferredBrowserBaseURL } from "./tests/runtime-defaults";
 
-const E2E_TIER = String(process.env.PULSE_E2E_TIER || '')
+const E2E_TIER = String(process.env.PULSE_E2E_TIER || "")
   .trim()
   .toLowerCase();
-if (E2E_TIER && E2E_TIER !== 'stable' && E2E_TIER !== 'probation') {
+if (E2E_TIER && E2E_TIER !== "stable" && E2E_TIER !== "probation") {
   throw new Error(
     `PULSE_E2E_TIER must be "stable", "probation", or unset (got "${E2E_TIER}")`,
   );
 }
 // Stable tier ignores probation specs; probation tier runs only them.
-const TIER_IGNORE = E2E_TIER === 'stable' ? PROBATION_SPECS : [];
+const TIER_IGNORE = E2E_TIER === "stable" ? PROBATION_SPECS : [];
 
 // CI runs both tiers inside one job; separate output roots keep the
 // probation pass from clobbering the stable pass's report and artifacts.
-const REPORT_DIR = process.env.PULSE_E2E_REPORT_DIR || 'playwright-report';
-const RESULTS_DIR = process.env.PULSE_E2E_RESULTS_DIR || 'test-results';
+const REPORT_DIR = process.env.PULSE_E2E_REPORT_DIR || "playwright-report";
+const RESULTS_DIR = process.env.PULSE_E2E_RESULTS_DIR || "test-results";
 
 /**
  * Playwright configuration for Pulse update integration tests
  * See https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  testDir: './tests',
+  testDir: "./tests",
 
-  ...(E2E_TIER === 'probation' ? { testMatch: PROBATION_SPECS } : {}),
+  ...(E2E_TIER === "probation" ? { testMatch: PROBATION_SPECS } : {}),
 
   outputDir: RESULTS_DIR,
 
@@ -53,9 +50,16 @@ export default defineConfig({
 
   /* Reporter to use */
   reporter: [
-    ['html', { outputFolder: REPORT_DIR, open: 'never' }],
-    ['list'],
-    ['junit', { outputFile: `${RESULTS_DIR}/junit.xml` }]
+    ["html", { outputFolder: REPORT_DIR, open: "never" }],
+    ["list"],
+    // Keep gating failures queryable through the check-run annotations API.
+    // Raw Actions logs and report archives can exceed the maintainer's bounded
+    // evidence surface; the built-in reporter includes project, spec, line,
+    // and test title without changing retries, tiering, or the verdict.
+    ...(process.env.GITHUB_ACTIONS === "true" && E2E_TIER === "stable"
+      ? ([["github"]] as const)
+      : []),
+    ["junit", { outputFile: `${RESULTS_DIR}/junit.xml` }],
   ],
 
   /* Shared test timeout */
@@ -70,18 +74,20 @@ export default defineConfig({
     baseURL: preferredBrowserBaseURL(),
 
     /* Allow testing against self-signed TLS when explicitly enabled */
-    ignoreHTTPSErrors: ['1', 'true', 'yes', 'on'].includes(
-      String(process.env.PULSE_E2E_INSECURE_TLS || '').trim().toLowerCase(),
+    ignoreHTTPSErrors: ["1", "true", "yes", "on"].includes(
+      String(process.env.PULSE_E2E_INSECURE_TLS || "")
+        .trim()
+        .toLowerCase(),
     ),
 
     /* Collect trace when retrying the failed test */
-    trace: 'on-first-retry',
+    trace: "on-first-retry",
 
     /* Screenshot on failure */
-    screenshot: 'only-on-failure',
+    screenshot: "only-on-failure",
 
     /* Video on failure */
-    video: 'retain-on-failure',
+    video: "retain-on-failure",
 
     /* Default navigation timeout */
     navigationTimeout: 15000,
@@ -93,18 +99,22 @@ export default defineConfig({
   /* Configure projects for different browsers */
   projects: [
     {
-      name: 'chromium',
+      name: "chromium",
       use: {
-        ...devices['Desktop Chrome'],
+        ...devices["Desktop Chrome"],
       },
       // Mobile-specific tests are intentionally excluded from the desktop project;
       // they rely on mobile viewports where md:hidden nav is visible, tables overflow, etc.
-      testIgnore: [...QUARANTINED_SPECS, ...TIER_IGNORE, '**/04-mobile.spec.ts'],
+      testIgnore: [
+        ...QUARANTINED_SPECS,
+        ...TIER_IGNORE,
+        "**/04-mobile.spec.ts",
+      ],
     },
     {
-      name: 'mobile-chrome',
+      name: "mobile-chrome",
       use: {
-        ...devices['Pixel 5'],
+        ...devices["Pixel 5"],
       },
       // Journey tests skip on mobile projects (all use test.skip for mobile-*),
       // so exclude them to avoid unnecessary browser launches. The visual
@@ -113,20 +123,20 @@ export default defineConfig({
       testIgnore: [
         ...QUARANTINED_SPECS,
         ...TIER_IGNORE,
-        '**/journeys/**',
-        '**/99-visual-crawl.spec.ts',
+        "**/journeys/**",
+        "**/99-visual-crawl.spec.ts",
       ],
     },
     {
-      name: 'mobile-safari',
+      name: "mobile-safari",
       use: {
-        ...devices['iPhone 12'],
+        ...devices["iPhone 12"],
       },
       testIgnore: [
         ...QUARANTINED_SPECS,
         ...TIER_IGNORE,
-        '**/journeys/**',
-        '**/99-visual-crawl.spec.ts',
+        "**/journeys/**",
+        "**/99-visual-crawl.spec.ts",
       ],
     },
 


### PR DESCRIPTION
## Summary

- semantically rebase the still-needed PR #1749 release-verification proofs onto current `main`, dropping its Workloads formatting-only change because current main already has the exact blob
- classify PR #1749's Core E2E red as inherited rather than candidate-caused: base `5ed053d`, exact head `bcca69c`, and current main `ad91258` all fail the same stable shards 3/6/8 while 1/2/4/5/7 pass
- enable Playwright's pinned GitHub reporter only for the gating stable tier so failed project/spec/line/test identities are available through bounded check-run annotations

The reporter does not change tier membership, retries, exit status, artifacts, or the final E2E verdict. Probation remains non-gating and does not emit these annotations. This is durable diagnostic containment for the inherited stable failure; the exact failing test/product defect will be corrected on this candidate once the new exact-head annotations identify it.

## Validation

- `npm run check:e2e-tiers` (95 specs; 50 stable, 42 probation, 3 quarantined; 291/535 stable/probation instances)
- stable GitHub-Actions Playwright `--list` emitted the GitHub reporter summary; identical probation selection emitted no workflow annotation commands
- focused `go test` for Docker credential path handling and host-agent absolute helper paths
- exact release-promotion policy test
- Workloads selector Vitest: 30/30
- Prettier for Workloads selector and Playwright config
- `git diff --check`

No release, tag, deployment, or live configuration was changed.