### PR TITLE
Restore owner risk acceptance wording

### DIFF
--- a/docs/release-control/v6/internal/status.json
+++ b/docs/release-control/v6/internal/status.json
@@ -9049,7 +9049,7 @@
     },
     {
       "id": "rc-to-ga-promotion-readiness",
-      "summary": "Confirm Pulse v6 stable promotion uses a governed exact-SHA rehearsal, published prerelease lineage, explicit owner acceptance for any shortened soak or bounded post-RC cutoff, exact rollback instructions, and the written v5 maintenance-only policy; v6.3.0 promoted from rc.6 after clean privacy-safe production telemetry and converged from the unchanged stable cutoff SHA.",
+      "summary": "Confirm Pulse v6 stable promotion uses a governed exact-SHA rehearsal, published prerelease lineage, explicit owner risk acceptance for any shortened soak or bounded post-RC cutoff, exact rollback instructions, and the written v5 maintenance-only policy; v6.3.0 promoted from rc.6 after clean privacy-safe production telemetry and converged from the unchanged stable cutoff SHA.",
       "owner": "project-owner",
       "blocking_level": "release-ready",
       "minimum_evidence_tier": "real-external-e2e",


### PR DESCRIPTION
## Summary

- restore the explicit owner risk-acceptance wording in the `rc-to-ga-promotion-readiness` gate summary
- preserve the existing gate status, blocking level, evidence tier, and all evidence records
- keep this correction independent of PR #1759 and PBS alert work

## Validation

- `python3 scripts/release_control/release_promotion_policy_test.py` (43 tests passed)
- canonical completion guard for the changed status path
- Pulse Intelligence schema validation and unit tests
- canonical completion, browser verification, control-plane, formatter, governance-stage, registry-audit, repo-file-I/O, status-audit, and subsystem-contract unit tests
- canonical mutation-registry Go checks
- active-target readiness assertion guard

The full Canonical Governance workflow is required for the private sibling-repository audits that cannot run in this isolated task workspace.