### PR TITLE
Synchronize TrueNAS storage drawer search

### DIFF
--- a/tests/integration/tests/27-truenas-storage-disk-history.spec.ts
+++ b/tests/integration/tests/27-truenas-storage-disk-history.spec.ts
@@ -57,9 +57,9 @@ test.describe('TrueNAS storage disk history', () => {
     });
 
     await page.goto('/truenas/storage', { waitUntil: 'domcontentloaded' });
-    await page
-      .getByRole('textbox', { name: /Search TrueNAS/ })
-      .fill('sdc');
+    const search = page.getByRole('combobox', { name: /Search TrueNAS/ });
+    await expect(search).toBeVisible();
+    await search.fill('sdc');
 
     const diskRow = page.locator('tr').filter({ hasText: 'sdc' }).first();
     await expect(diskRow).toBeVisible();


### PR DESCRIPTION
## Summary

- target the rendered TrueNAS storage search as its accessible `combobox` role
- explicitly require the hydrated control to be visible before filling it
- keep product behavior, timeouts, browser coverage, tier policy, Patrol, and PBS alert surfaces unchanged

## Evidence

Authenticated inherited run `32579993104`, shard 3/8 job `97047850921`, failed at commit `c313a80daa58e950d531251ab1f45c48f1d291e1` on both attempts with `locator.fill: Timeout 10000ms exceeded` at this spec's search fill.

On authenticated current main `434e1448ff70464bccec3e6ec46257d10da2162f`, the unmodified focused desktop Chromium test reproduced the same 10-second fill timeout. Its rendered failure state and accessibility snapshot showed the page was fully hydrated, including the `sdc` row, while the search control was exposed as `combobox "Search TrueNAS pools, datasets, or disks"`; there was no textbox match.

After this one-file synchronization correction:

- focused journey: 1/1 passed (2.3s)
- rendered-evidence journey: 1/1 passed (2.5s), showing the hydrated search and intended `sdc` drawer
- repeated focused proof: 5/5 passed with one worker (10.1s total)
- scoped `git diff --check`: passed

The first runnable failure was retained and not rerun as a green substitute. Earlier setup-only failures (read-only caches and missing Chromium libraries) occurred before navigation and are not test verdicts.

Contract-Neutral: true