### PR TITLE
Contain release qualification source trust boundary

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -760,8 +760,7 @@ jobs:
     if: ${{ always() && inputs.qualify_containers && needs.build.result == 'success' }}
     permissions:
       contents: read
-    uses: ./.github/workflows/qualify-release-containers.yml
+    uses: rcourtman/Pulse/.github/workflows/qualify-release-containers.yml@main
     with:
       version: ${{ inputs.version }}
       container_artifact: ${{ needs.build.outputs.container_artifact_name }}
-      source_sha: ${{ github.sha }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -251,11 +251,10 @@ jobs:
     if: ${{ always() && needs.prepare.result == 'success' && needs.build_release_candidate.result == 'success' && needs.prepare.outputs.historical_asset_backfill_only != 'true' }}
     permissions:
       contents: read
-    uses: ./.github/workflows/qualify-release-containers.yml
+    uses: rcourtman/Pulse/.github/workflows/qualify-release-containers.yml@main
     with:
       version: ${{ needs.prepare.outputs.version }}
       container_artifact: ${{ needs.build_release_candidate.outputs.container_artifact_name }}
-      source_sha: ${{ github.sha }}
 
   # Build the embed bundle independently so backend and smoke lanes can start
   # without waiting for the full frontend quality suite.

--- a/.github/workflows/qualify-release-containers.yml
+++ b/.github/workflows/qualify-release-containers.yml
@@ -11,24 +11,47 @@ on:
         description: 'Exact-candidate container payload artifact from this run'
         required: true
         type: string
-      source_sha:
-        description: 'Exact source commit bound to the candidate payload'
-        required: true
-        type: string
-
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
+  authorize-source:
+    name: Authorize Immutable Default-Branch Source
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    steps:
+      - name: Reject unapproved source revisions
+        env:
+          SOURCE_REPOSITORY: ${{ github.repository }}
+          SOURCE_REF: ${{ github.ref }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$SOURCE_REPOSITORY" != "rcourtman/Pulse" ]; then
+            echo "::error::Release container qualification is restricted to rcourtman/Pulse."
+            exit 1
+          fi
+          if [ "$SOURCE_REF" != "refs/heads/main" ]; then
+            echo "::error::Release container qualification requires refs/heads/main; received ${SOURCE_REF}."
+            exit 1
+          fi
+          if [[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Release container qualification requires an immutable commit SHA."
+            exit 1
+          fi
+
   qualify:
     name: Exact-Candidate Container and Helm Smoke
+    needs: authorize-source
+    if: ${{ needs.authorize-source.result == 'success' }}
+    permissions:
+      contents: read
     runs-on: [self-hosted, Linux, X64, pulse-pve-build]
     timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ github.sha }}
 
       - name: Download exact-candidate container payload
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -42,7 +65,7 @@ jobs:
             --release-dir "$RUNNER_TEMP/release-container-payload/payload" \
             --manifest "$RUNNER_TEMP/release-container-payload/release-container-payload.json" \
             --version "${{ inputs.version }}" \
-            --source-sha "${{ inputs.source_sha }}"
+            --source-sha "${{ github.sha }}"
 
       - name: Assemble exact-candidate runtime and agent images
         run: |

--- a/scripts/installtests/build_release_assets_test.go
+++ b/scripts/installtests/build_release_assets_test.go
@@ -1392,7 +1392,6 @@ func TestReleaseWorkflowsUseSecretSafeAttestedImageBuilds(t *testing.T) {
 		`./scripts/prepare-release-container-context.sh`,
 		`container_artifact_name`,
 		`container_artifact: ${{ needs.build_release_candidate.outputs.container_artifact_name }}`,
-		`source_sha: ${{ github.sha }}`,
 		`release-container-payload.json`,
 		`--target runtime_prebuilt`,
 		`--target agent_runtime_prebuilt`,
@@ -1496,6 +1495,142 @@ func TestReleaseWorkflowsUseSecretSafeAttestedImageBuilds(t *testing.T) {
 	} {
 		if strings.Contains(publish, forbidden) {
 			t.Fatalf("publish-docker.yml must assemble the verified candidate without release build secrets: %s", forbidden)
+		}
+	}
+}
+
+func TestReleaseContainerQualificationRejectsUnapprovedSourcesBeforeSelfHostedExecution(t *testing.T) {
+	qualifierBytes, err := os.ReadFile(repoFile(".github", "workflows", "qualify-release-containers.yml"))
+	if err != nil {
+		t.Fatalf("read qualify-release-containers.yml: %v", err)
+	}
+	candidateBytes, err := os.ReadFile(repoFile(".github", "workflows", "build-release-candidate.yml"))
+	if err != nil {
+		t.Fatalf("read build-release-candidate.yml: %v", err)
+	}
+	releaseBytes, err := os.ReadFile(repoFile(".github", "workflows", "create-release.yml"))
+	if err != nil {
+		t.Fatalf("read create-release.yml: %v", err)
+	}
+
+	qualifier := string(qualifierBytes)
+	authorizeJob := workflowJobBlock(t, qualifier, "authorize-source")
+	qualifyJob := workflowJobBlock(t, qualifier, "qualify")
+	for _, needle := range []string{
+		"runs-on: ubuntu-24.04",
+		`SOURCE_REPOSITORY: ${{ github.repository }}`,
+		`SOURCE_REF: ${{ github.ref }}`,
+		`SOURCE_SHA: ${{ github.sha }}`,
+		`if [ "$SOURCE_REPOSITORY" != "rcourtman/Pulse" ]; then`,
+		`if [ "$SOURCE_REF" != "refs/heads/main" ]; then`,
+		`[[ ! "$SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]`,
+	} {
+		if !strings.Contains(authorizeJob, needle) {
+			t.Fatalf("release source authorization must fail closed before self-hosted execution: %s", needle)
+		}
+	}
+	if strings.Contains(authorizeJob, "actions/checkout") || strings.Contains(authorizeJob, "self-hosted") || strings.Contains(authorizeJob, "uses:") {
+		t.Fatal("release source authorization must not check out or execute repository content on a self-hosted runner")
+	}
+	for _, needle := range []string{
+		"needs: authorize-source",
+		`if: ${{ needs.authorize-source.result == 'success' }}`,
+		"permissions:\n      contents: read",
+		"runs-on: [self-hosted, Linux, X64, pulse-pve-build]",
+		`ref: ${{ github.sha }}`,
+		`--source-sha "${{ github.sha }}"`,
+	} {
+		if !strings.Contains(qualifyJob, needle) {
+			t.Fatalf("release container qualification must preserve the authorized immutable source: %s", needle)
+		}
+	}
+	if strings.Contains(qualifier, "inputs.source_sha") || strings.Contains(qualifier, "source_sha:") {
+		t.Fatal("trusted qualifier must derive source identity from GitHub's immutable caller SHA, not caller-controlled input")
+	}
+	if !strings.Contains(qualifier, "permissions: {}") {
+		t.Fatal("source authorization must not receive a repository token")
+	}
+
+	runMarker := "        run: |\n"
+	runStart := strings.Index(authorizeJob, runMarker)
+	if runStart == -1 {
+		t.Fatal("release source authorization must use one auditable inline gate")
+	}
+	gateLines := strings.Split(authorizeJob[runStart+len(runMarker):], "\n")
+	for i, line := range gateLines {
+		gateLines[i] = strings.TrimPrefix(line, "          ")
+	}
+	gateScript := strings.TrimSpace(strings.Join(gateLines, "\n"))
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash is required to execute the GitHub-hosted authorization gate")
+	}
+	for _, tc := range []struct {
+		name       string
+		repository string
+		ref        string
+		sha        string
+		wantOK     bool
+	}{
+		{name: "approved main commit", repository: "rcourtman/Pulse", ref: "refs/heads/main", sha: strings.Repeat("a", 40), wantOK: true},
+		{name: "wrong repository", repository: "someone/Pulse", ref: "refs/heads/main", sha: strings.Repeat("a", 40)},
+		{name: "feature branch", repository: "rcourtman/Pulse", ref: "refs/heads/feature", sha: strings.Repeat("a", 40)},
+		{name: "tag", repository: "rcourtman/Pulse", ref: "refs/tags/v6.3.0", sha: strings.Repeat("a", 40)},
+		{name: "symbolic sha", repository: "rcourtman/Pulse", ref: "refs/heads/main", sha: "main"},
+		{name: "uppercase sha", repository: "rcourtman/Pulse", ref: "refs/heads/main", sha: strings.Repeat("A", 40)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.Command(bashPath, "-c", gateScript)
+			cmd.Env = append(os.Environ(),
+				"SOURCE_REPOSITORY="+tc.repository,
+				"SOURCE_REF="+tc.ref,
+				"SOURCE_SHA="+tc.sha,
+			)
+			err := cmd.Run()
+			if tc.wantOK && err != nil {
+				t.Fatalf("approved source rejected: %v", err)
+			}
+			if !tc.wantOK && err == nil {
+				t.Fatal("unapproved source passed release authorization")
+			}
+		})
+	}
+
+	trustedQualifier := "uses: rcourtman/Pulse/.github/workflows/qualify-release-containers.yml@main"
+	candidateQualifier := workflowJobBlock(t, string(candidateBytes), "qualify-release-containers")
+	releaseQualifier := workflowJobBlock(t, string(releaseBytes), "qualify_release_containers")
+	for workflowName, qualifierJob := range map[string]string{
+		"build-release-candidate.yml": candidateQualifier,
+		"create-release.yml":          releaseQualifier,
+	} {
+		if !strings.Contains(qualifierJob, trustedQualifier) {
+			t.Fatalf("%s must resolve privileged qualification from the trusted default branch", workflowName)
+		}
+		if strings.Contains(qualifierJob, "uses: ./.github/workflows/qualify-release-containers.yml") {
+			t.Fatalf("%s must not let a selected dispatch ref replace the privileged qualifier", workflowName)
+		}
+		if strings.Contains(qualifierJob, "source_sha:") {
+			t.Fatalf("%s qualifier call must not reintroduce a selectable source revision", workflowName)
+		}
+	}
+
+	workflowPaths, err := filepath.Glob(repoFile(".github", "workflows", "*.yml"))
+	if err != nil {
+		t.Fatalf("list workflows: %v", err)
+	}
+	for _, workflowPath := range workflowPaths {
+		workflowBytes, err := os.ReadFile(workflowPath)
+		if err != nil {
+			t.Fatalf("read %s: %v", workflowPath, err)
+		}
+		workflow := string(workflowBytes)
+		if strings.Contains(workflow, "uses: ./.github/workflows/qualify-release-containers.yml") {
+			t.Fatalf("%s must not resolve privileged qualification from a selectable caller revision", workflowPath)
+		}
+		for _, line := range strings.Split(workflow, "\n") {
+			if strings.Contains(line, "uses:") && strings.Contains(line, "qualify-release-containers.yml") && !strings.Contains(line, trustedQualifier) {
+				t.Fatalf("%s contains an untrusted release qualifier reference: %s", workflowPath, strings.TrimSpace(line))
+			}
 		}
 	}
 }
@@ -2663,7 +2798,7 @@ func TestReleaseCutGatesCriticalFrontendAndWindowsRuntimeProof(t *testing.T) {
 		}
 	}
 	if !strings.Contains(workflow, "qualify_containers: false") ||
-		!strings.Contains(workflow, "uses: ./.github/workflows/qualify-release-containers.yml") {
+		!strings.Contains(workflow, "uses: rcourtman/Pulse/.github/workflows/qualify-release-containers.yml@main") {
 		t.Fatal("publishing release must qualify the candidate beside inert draft staging")
 	}
 	if !strings.Contains(verdictJob, `require_result "Windows install command smoke" "$WINDOWS_INSTALL_COMMAND_RESULT" success`) {


### PR DESCRIPTION
## Summary

Contain CodeQL alert 322's release-qualification checkout boundary without changing candidate provenance:

- resolve the privileged reusable qualifier from the trusted default branch instead of the selected caller revision
- authorize repository, branch, and immutable caller SHA on a tokenless GitHub-hosted job before scheduling the self-hosted qualifier
- remove the caller-controlled `source_sha` input and use the caller-associated `github.sha` for both checkout and manifest verification
- enforce the boundary with behavioral rejection cases and a repository-wide qualifier reference scan

## Incident evidence

The authenticated vulnerable-window audit covered every relevant run since the dataflow was introduced: 2 direct builder runs, 13 release-pipeline runs, and 5 dry runs. All 20 were first-attempt owner dispatches from `main`; no unexpected actor, branch, or revision was observed. Nine qualifier jobs reached the build runner: seven succeeded, one was cancelled, and one failed only after successful checkout, manifest verification, image assembly, and binary identity checks because `kubectl` was unavailable.

The v6.3.0-rc.6 and v6.3.0 publication runs both completed exact-SHA manifest verification, container binary identity comparison, and Helm qualification. Their candidate, manifest, compiled-payload, and container-payload artifacts are SHA-bound and have GitHub-recorded digests. No contaminated cache, runner revision, artifact, release, credential, or customer binary is evidenced, so no destructive cleanup is proposed.

## Validation

- `go test ./scripts/installtests -run '^TestRelease' -count=1`
- `python3 -m unittest control_plane_audit_test.py release_promotion_policy_test.py resolve_release_promotion_test.py` (79 tests)
- `bash scripts/tests/test-script-reference-integrity.sh`
- parse every `.github/workflows/*.yml` with PyYAML

## Scope

This closes the direct input-to-privileged-checkout path while preserving current v6 and legacy 5.1 policy, both of which resolve releases to `main`. Manual dispatch already requires repository write access; provider-side branch protection and workflow-scoped runner groups remain broader governance hardening and are not claimed by this diff.

Rollback is an exact revert of this commit; affected qualifier dispatch entry points must remain disabled until equivalent trusted-ref containment is restored.

Contract-Neutral: release-workflow hardening only; no product runtime contract changes.