### PR TITLE
Bind release container qualification to caller commit

### DIFF
--- a/.github/workflows/build-release-candidate.yml
+++ b/.github/workflows/build-release-candidate.yml
@@ -862,4 +862,3 @@ jobs:
     with:
       version: ${{ inputs.version }}
       container_artifact: ${{ needs.build.outputs.container_artifact_name }}
-      source_sha: ${{ github.sha }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -257,7 +257,6 @@ jobs:
     with:
       version: ${{ needs.prepare.outputs.version }}
       container_artifact: ${{ needs.build_release_candidate.outputs.container_artifact_name }}
-      source_sha: ${{ github.sha }}
 
   # Build the embed bundle independently so backend and smoke lanes can start
   # without waiting for the full frontend quality suite.

--- a/.github/workflows/qualify-release-containers.yml
+++ b/.github/workflows/qualify-release-containers.yml
@@ -11,10 +11,6 @@ on:
         description: 'Exact-candidate container payload artifact from this run'
         required: true
         type: string
-      source_sha:
-        description: 'Exact source commit bound to the candidate payload'
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -31,7 +27,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ref: ${{ inputs.source_sha }}
+          # A reusable workflow inherits github.sha from its caller. Do not
+          # accept a caller-controlled checkout ref: the caller event commit is
+          # the immutable source identity for both code and candidate payload.
+          ref: ${{ github.sha }}
+          persist-credentials: false
+
+      - name: Verify exact caller source
+        env:
+          EXPECTED_SOURCE_SHA: ${{ github.sha }}
+        run: test "$(git rev-parse HEAD)" = "${EXPECTED_SOURCE_SHA}"
 
       - name: Download exact-candidate container payload
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -45,7 +50,7 @@ jobs:
             --release-dir "$RUNNER_TEMP/release-container-payload/payload" \
             --manifest "$RUNNER_TEMP/release-container-payload/release-container-payload.json" \
             --version "${{ inputs.version }}" \
-            --source-sha "${{ inputs.source_sha }}"
+            --source-sha "${{ github.sha }}"
 
       - name: Assemble exact-candidate runtime and agent images
         run: |

--- a/scripts/installtests/build_release_assets_test.go
+++ b/scripts/installtests/build_release_assets_test.go
@@ -1512,6 +1512,56 @@ func TestReleaseWorkflowsUseSecretSafeAttestedImageBuilds(t *testing.T) {
 	}
 }
 
+func TestReleaseContainerQualificationBindsCheckoutToCallerCommit(t *testing.T) {
+	qualifierBytes, err := os.ReadFile(repoFile(".github", "workflows", "qualify-release-containers.yml"))
+	if err != nil {
+		t.Fatalf("read qualify-release-containers.yml: %v", err)
+	}
+	candidateBytes, err := os.ReadFile(repoFile(".github", "workflows", "build-release-candidate.yml"))
+	if err != nil {
+		t.Fatalf("read build-release-candidate.yml: %v", err)
+	}
+	releaseBytes, err := os.ReadFile(repoFile(".github", "workflows", "create-release.yml"))
+	if err != nil {
+		t.Fatalf("read create-release.yml: %v", err)
+	}
+
+	qualifier := string(qualifierBytes)
+	qualifyJob := workflowJobBlock(t, qualifier, "qualify")
+	for _, required := range []string{
+		`ref: ${{ github.sha }}`,
+		`persist-credentials: false`,
+		`EXPECTED_SOURCE_SHA: ${{ github.sha }}`,
+		`test "$(git rev-parse HEAD)" = "${EXPECTED_SOURCE_SHA}"`,
+		`--source-sha "${{ github.sha }}"`,
+	} {
+		if !strings.Contains(qualifyJob, required) {
+			t.Fatalf("release container qualification does not fail closed on the exact caller commit: %s", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"inputs.source_sha",
+		"source_sha:",
+	} {
+		if strings.Contains(qualifier, forbidden) {
+			t.Fatalf("release container qualification must not accept an arbitrary source ref: %s", forbidden)
+		}
+	}
+
+	callerJobs := map[string]string{
+		"build-release-candidate.yml": workflowJobBlock(t, string(candidateBytes), "qualify-release-containers"),
+		"create-release.yml":          workflowJobBlock(t, string(releaseBytes), "qualify_release_containers"),
+	}
+	for caller, job := range callerJobs {
+		if strings.Contains(job, "source_sha:") {
+			t.Fatalf("%s must not forward a caller-selectable source ref to container qualification", caller)
+		}
+		if !strings.Contains(job, "uses: ./.github/workflows/qualify-release-containers.yml") {
+			t.Fatalf("%s no longer calls the trusted container qualifier", caller)
+		}
+	}
+}
+
 func TestDeploymentDefaultsPinVersionedImagesAndHelmDocsChecksum(t *testing.T) {
 	versionBytes, err := os.ReadFile(repoFile("VERSION"))
 	if err != nil {


### PR DESCRIPTION
## Security containment

Closes the caller-controlled checkout path reported by CodeQL alert 322 without changing release publication behavior.

- removes `source_sha` from the reusable container qualifier and both direct callers
- checks out only the reusable workflow caller's immutable `github.sha`
- disables persisted checkout credentials
- verifies checked-out HEAD before artifact download or repository execution
- verifies the candidate payload manifest against that same caller SHA
- adds fail-closed source-interface and mismatch guardrail coverage

Artifact names, version/source manifest binding, container binary comparisons, least-privilege permissions, and existing stable/prerelease runner selection remain intact.

## Validation

- `go test -p 1 ./scripts/installtests -run 'TestRelease' -count=1`
- `python3 scripts/release_control/release_promotion_policy_test.py` (43 tests)
- focused release workflow integrity tests
- candidate-only `git diff --check`
- independent security review
- authenticated review of 26 post-alert caller runs, 12 executed qualifier jobs, current cache metadata, runner registration, and release artifact identities found no anomalous ref, source/digest/binary mismatch, unexpected cache namespace, or positive compromise signal

No release, tag, package, image, deployment, cache mutation, credential rotation, or runner mutation was performed.