### PR TITLE
Restore release confidence after drawer refactors

### DIFF
--- a/tests/integration/tests/36-vmware-alert-history-resource-incidents.spec.ts
+++ b/tests/integration/tests/36-vmware-alert-history-resource-incidents.spec.ts
@@ -172,7 +172,7 @@ test.describe("VMware alert history resource incidents", () => {
 
     await ensureAuthenticated(page);
 
-    await page.goto("/alerts/history", {
+    await page.goto("/alerts/history?q=app-01", {
       waitUntil: "domcontentloaded",
     });
 

--- a/tests/integration/tests/60-page-header-consistency.spec.ts
+++ b/tests/integration/tests/60-page-header-consistency.spec.ts
@@ -29,7 +29,8 @@ const PAGE_HEADER_ROUTES = [
     slug: "patrol",
     route: "/patrol",
     title: "Patrol",
-    description: "Patrol checks your infrastructure and shows current issues.",
+    description:
+      "See what needs a decision, choose the next step, and keep a verified record.",
   },
 ] as const;
 


### PR DESCRIPTION
## Summary

- restore the Kubernetes platform-capability badges that remained in derived state but lost their only renderer
- keep small non-windowed platform lists reactive when asynchronous inventory/history arrives
- align stale drawer and stable E2E contracts with current Manage ownership, collapsed details, canonical backup routing, inventory readiness, scoped alert history, and Patrol copy
- preserve the existing bundle budget by moving incremental patch-index selection into the shared resource adapter

This is the bounded repair for release incident `775fe7fe20524e56`. It is based on current main `7e363e40e7aa21bf4d5029108a217c0f93b963b5` and explicitly preserves the independently integrated drawer-density, discovery-identity, and full-width-header work.

## Validation

- complete frontend suite at the repaired source boundary: 1,144 files passed, one skipped; 20,654 tests passed, three skipped
- post-sync candidate/upstream overlap suite: 20 files, 414/414 tests passed
- type-check, formatting, full lint, header audit, production build, duplication audit, and bundle-size gate passed
- no bundle baseline changed; `useUnifiedResources` remains within the existing 6.62 kB maximum
- E2E tier selection passed; affected specs collect as 24 tests across Chromium, mobile Chrome, and mobile Safari
- rendered public 6.3.1 Patrol baseline inspected at 1280 px and 390 px

Exact-head Build and Test and Core E2E remain required. The release hold stays in place until both are terminal green on this same head.

## Rollback

Revert only this incident repair commit. Do not revert the independently integrated drawer-density, discovery-identity, or full-width-header commits. If either required workflow regresses, keep the release hold and revert this candidate through the governed path.