### PR TITLE
Fix replayed typed-request handling and two Linux/Windows-only test gaps

### DIFF
--- a/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
+++ b/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
@@ -7415,6 +7415,11 @@ kept running on the Proxmox host). Three coupled guarantees:
    connection-generation-scoped state table. Cancellation or connection
    teardown before handler registration leaves a tombstone that registration
    consumes atomically, so provider handoff cannot start after abandonment.
+   A replay of a request ID that arrives while the previous handler still
+   owns its slot waits for that slot to be released and then runs, so it
+   answers from the durable receipt; it is never dropped as a duplicate,
+   because the server replays exact request IDs to recover receipts and a
+   dropped replay would leave the server waiting out the full timeout.
 3. The unified agent's command client tracks in-flight
    `execute_command`/`read_file` executions and durable host update,
    storage-cleanup, Proxmox guest lifecycle, and container lifecycle/update
@@ -7445,7 +7450,8 @@ Proofs: `internal/agentexec/server_websocket_test.go`
 (`TestCommandClient_handleCancelCommand_CancelsRegisteredRequest`,
 `TestCommandClient_handleCancelCommand_UnknownRequestIsNoOp`,
 `TestCommandClient_CancellationBeforeRegistrationIsConsumedAndConnectionScoped`,
-`TestCommandClient_StaleCleanupCannotEraseReusedRequestCancellation`),
+`TestCommandClient_StaleCleanupCannotEraseReusedRequestCancellation`,
+`TestCommandClient_ReplayedRequestWaitsForInFlightHandlerInsteadOfDropping`),
 `internal/hostagent/proxmox_guest_lifecycle_test.go`
 (`TestProxmoxGuestLifecycleCancellationBeforeHandlerRegistrationSkipsProviderAndPersistsReceipt`), and
 `internal/hostagent/commands_execute_unix_test.go` (timeout and cancel

--- a/internal/hostagent/command_client_test.go
+++ b/internal/hostagent/command_client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/rcourtman/pulse-go-rewrite/internal/agentexec"
@@ -465,5 +466,51 @@ func TestCommandClientActionRunnerMessageCatalogRejectsGenericAuthority(t *testi
 		if !allowedActionRunnerMessage(message) {
 			t.Fatalf("action runner rejected typed message %q", message)
 		}
+	}
+}
+
+func TestCommandClient_ReplayedRequestWaitsForInFlightHandlerInsteadOfDropping(t *testing.T) {
+	c := &CommandClient{logger: zerolog.Nop()}
+	conn := &websocket.Conn{}
+	const requestID = "typed-replay"
+
+	release := make(chan struct{})
+	firstRunning := make(chan struct{})
+	secondRan := make(chan struct{})
+	c.launchCancellableRequest(conn, requestID, "typed", func() {
+		close(firstRunning)
+		<-release
+	})
+	select {
+	case <-firstRunning:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first handler did not start")
+	}
+
+	// The replay arrives while the first handler still owns the slot. It must
+	// not be dropped; it runs once the first handler releases the slot, so it
+	// can answer from the durable receipt.
+	c.launchCancellableRequest(conn, requestID, "typed", func() { close(secondRan) })
+	select {
+	case <-secondRan:
+		t.Fatal("replay ran while the first handler still owned the slot")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if c.inflightCancellableRequest(conn, requestID) == nil {
+		t.Fatal("first handler lost its slot before finishing")
+	}
+
+	close(release)
+	select {
+	case <-secondRan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("replay was dropped instead of running after the first handler finished")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for c.inflightCancellableRequest(conn, requestID) != nil && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if c.inflightCancellableRequest(conn, requestID) != nil {
+		t.Fatal("replay handler did not release the slot")
 	}
 }

--- a/internal/hostagent/commands.go
+++ b/internal/hostagent/commands.go
@@ -157,6 +157,14 @@ type cancellableRequestKey struct {
 type cancellableRequestState struct {
 	cancel   context.CancelFunc
 	canceled bool
+	// done closes when the request releases its slot, so a replay of the same
+	// request id that arrives while the previous handler is still finishing
+	// can wait for it instead of being dropped.
+	done chan struct{}
+}
+
+func newCancellableRequestState() *cancellableRequestState {
+	return &cancellableRequestState{done: make(chan struct{})}
 }
 
 // NewCommandClient creates a new command execution client
@@ -618,13 +626,39 @@ func computeReconnectDelay(failures int) time.Duration {
 func (c *CommandClient) launchCancellableRequest(conn *websocket.Conn, requestID, operation string, handle func()) {
 	state := c.noteCancellableRequest(conn, requestID)
 	if state == nil {
-		c.logger.Warn().Str("request_id", requestID).Str("operation", operation).Msg("Dropping duplicate, invalid, or over-capacity cancellable request")
+		// The server replays a request id it already dispatched when it wants
+		// the durable receipt again, and that replay can arrive on the reader
+		// before the previous handler goroutine has released its slot. Wait for
+		// that handler instead of dropping the replay, which would leave the
+		// server waiting out its full timeout for a result that already exists.
+		if inflight := c.inflightCancellableRequest(conn, requestID); inflight != nil {
+			go func() {
+				<-inflight.done
+				c.launchCancellableRequest(conn, requestID, operation, handle)
+			}()
+			return
+		}
+		c.logger.Warn().Str("request_id", requestID).Str("operation", operation).Msg("Dropping invalid or over-capacity cancellable request")
 		return
 	}
 	go func() {
 		defer c.finishCancellableRequest(conn, requestID, state)
 		handle()
 	}()
+}
+
+// inflightCancellableRequest returns the state currently registered for a
+// request id on this connection, or nil when the slot is free or the id is
+// invalid.
+func (c *CommandClient) inflightCancellableRequest(conn *websocket.Conn, requestID string) *cancellableRequestState {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" || len(requestID) > 128 {
+		return nil
+	}
+	key := cancellableRequestKey{connection: conn, requestID: requestID}
+	c.activeCommandsMu.Lock()
+	defer c.activeCommandsMu.Unlock()
+	return c.cancellableRequests[key]
 }
 
 func (c *CommandClient) handleMessages(ctx context.Context, conn *websocket.Conn) error {
@@ -1277,7 +1311,7 @@ func (c *CommandClient) noteCancellableRequest(conn *websocket.Conn, requestID s
 	if _, exists := c.cancellableRequests[key]; exists || len(c.cancellableRequests) >= maxCancellableRequestsPerConnection {
 		return nil
 	}
-	state := &cancellableRequestState{}
+	state := newCancellableRequestState()
 	c.cancellableRequests[key] = state
 	return state
 }
@@ -1298,7 +1332,7 @@ func (c *CommandClient) registerActiveCommand(conn *websocket.Conn, requestID st
 			cancel()
 			return nil, false
 		}
-		state = &cancellableRequestState{}
+		state = newCancellableRequestState()
 		c.cancellableRequests[key] = state
 	}
 	if state.cancel != nil {
@@ -1319,10 +1353,15 @@ func (c *CommandClient) registerActiveCommand(conn *websocket.Conn, requestID st
 func (c *CommandClient) finishCancellableRequest(conn *websocket.Conn, requestID string, state *cancellableRequestState) {
 	key := cancellableRequestKey{connection: conn, requestID: strings.TrimSpace(requestID)}
 	c.activeCommandsMu.Lock()
+	released := false
 	if current := c.cancellableRequests[key]; state != nil && current == state {
 		delete(c.cancellableRequests, key)
+		released = true
 	}
 	c.activeCommandsMu.Unlock()
+	if released && state.done != nil {
+		close(state.done)
+	}
 }
 
 func (c *CommandClient) clearCancellableRequests(conn *websocket.Conn) {

--- a/internal/hostagent/operation_receipt_websocket_integration_test.go
+++ b/internal/hostagent/operation_receipt_websocket_integration_test.go
@@ -308,6 +308,17 @@ func TestRealServerActionRunnerCancellationPersistsAndReplaysProxmoxReceiptAfter
 		case <-time.After(3 * time.Second):
 			t.Fatal("action runner did not stop")
 		}
+		// The client has exited, but the server observes the socket close on
+		// its own reader goroutine. Reconnecting before that lands would let
+		// startRunner see the stale session as "connected" and dispatch the
+		// replay to a dead socket.
+		deadline := time.Now().Add(3 * time.Second)
+		for server.IsAgentConnected(admission.AgentID) && time.Now().Before(deadline) {
+			time.Sleep(10 * time.Millisecond)
+		}
+		if server.IsAgentConnected(admission.AgentID) {
+			t.Fatal("server did not observe the action runner disconnect")
+		}
 	}
 
 	request := agentexec.ProxmoxGuestLifecyclePayload{

--- a/scripts/installtests/agent_state_dir_lifecycle_test.go
+++ b/scripts/installtests/agent_state_dir_lifecycle_test.go
@@ -1,3 +1,5 @@
+//go:build unix
+
 package installtests
 
 import (


### PR DESCRIPTION
## What changed

1. `internal/hostagent/commands.go`: a replayed request id that arrives while the previous handler still owns its per-connection slot now waits for that handler to release the slot and then runs (answering from the durable receipt) instead of being dropped as a duplicate. Invalid ids and over-capacity requests are still dropped. Unit test added.
2. `TestRealServerActionRunnerCancellationPersistsAndReplaysProxmoxReceiptAfterReconnect` waits until the agentexec server reports the first action runner disconnected before starting the second runner.
3. `scripts/installtests/agent_state_dir_lifecycle_test.go` is tagged `//go:build unix` because it calls `syscall.Mkfifo`, which does not exist on Windows.

## Why

1. Since 60d0651a88 every typed request registers a cancellable slot that its handler goroutine releases in a deferred cleanup after sending its result. The server replays a request id when it wants the durable receipt again, and that replay can reach the reader before the deferred release runs, so `launchCancellableRequest` dropped it and the server waited out the operation's full timeout. The Linux x64 leg of Unified Agent Native Verification failed this way on 12 of the last 25 `main` runs, always on a "replay 1" dispatch of host update, storage cleanup, or Docker lifecycle.
2. The reconnect test dispatched the replay while the stale session still counted as connected. Under `GOMAXPROCS=1` with the race detector (the sharded release preflight) it hit the 30s lifecycle timeout deterministically.
3. Since 53267e149d the `scripts/installtests` package has failed to compile on Windows (`undefined: syscall.Mkfifo`), so the `install.ps1` contract tests have not run there.

## What it answers

Release-blocking preflight failure, a chronically red Linux x64 native-verification leg, and a red Windows leg, all in the way of the `v6.4.3-rc.1` candidate (patch for #1815, #1820, #1753). Change 1 is a fix to code that has not shipped in any stable release.

## Evidence

- `GOMAXPROCS=1 go test ./internal/hostagent/ -run 'TestRealServerAndUnifiedAgentWebSocket|TestRealServerActionRunner' -race -count=3` passes with the branch; the reconnect test failed 3/3 at 30s before change 2.
- `go test ./internal/hostagent/ -race` passes for the whole package with the branch.
- `GOOS=windows GOARCH=amd64 go vet ./scripts/installtests/` passes after change 3.
- Native-verification history on `main`: Linux x64 failed 12/25 with `replay 1 ... timed out after 5s`; Windows x64 red since 14:54 UTC 2026-09-01 with the Mkfifo build error.
