### PR TITLE
Fix isolated rootful attester loading

### DIFF
--- a/scripts/release_control/secure_runtime_rootful_attestation_v1.py
+++ b/scripts/release_control/secure_runtime_rootful_attestation_v1.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import hashlib
+import importlib.util
 import json
 import re
 import stat
@@ -19,7 +20,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-import secure_runtime_rootless_attestation_v1 as hardened
+
+def _load_hardened_validator() -> Any:
+    module_path = Path(__file__).resolve().with_name("secure_runtime_rootless_attestation_v1.py")
+    spec = importlib.util.spec_from_file_location("secure_runtime_rootless_attestation_v1", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"unable to load hardened receipt validator from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+hardened = _load_hardened_validator()
 
 
 RECEIPT_SCHEMA_VERSION = 1

--- a/scripts/release_control/secure_runtime_rootful_attestation_v1_test.py
+++ b/scripts/release_control/secure_runtime_rootful_attestation_v1_test.py
@@ -69,6 +69,34 @@ class RootfulAttestationV1Test(unittest.TestCase):
     def tearDown(self) -> None:
         self.temp.cleanup()
 
+    def test_isolated_path_loader_resolves_exact_sibling_validator(self) -> None:
+        module_path = Path(attester.__file__).resolve()
+        probe = """
+import importlib.util
+import pathlib
+import sys
+
+module_path = pathlib.Path(sys.argv[1]).resolve(strict=True)
+spec = importlib.util.spec_from_file_location("rootful_validator", module_path)
+if spec is None or spec.loader is None:
+    raise SystemExit("unable to create rootful validator spec")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+if module.MAX_RECEIPT_BYTES <= 0:
+    raise SystemExit("rootful validator did not load hardened sibling constants")
+"""
+        result = subprocess.run(
+            [sys.executable, "-I", "-c", probe, str(module_path)],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_hardened_validator_is_loaded_from_exact_sibling_path(self) -> None:
+        expected = Path(attester.__file__).resolve().with_name("secure_runtime_rootless_attestation_v1.py")
+        self.assertEqual(Path(attester.hardened.__file__).resolve(), expected)
+
     @staticmethod
     def ts(index: int) -> str:
         value = datetime(2026, 9, 1, 10, tzinfo=timezone.utc) + timedelta(minutes=index)


### PR DESCRIPTION
## Summary

- Load the hardening validator from the attester exact sibling path so isolated file-based loading works.
- Add subprocess coverage for Python isolated mode and assert the exact sibling module identity.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest scripts.release_control.secure_runtime_rootful_attestation_v1_test`
- `go test ./scripts/installtests -run "TestSecureRuntimeRootful|TestRootful" -count=1`
- status, registry, and contract audits
- full pre-commit gate: 163 release-control tests
- pre-push frontend lint and type-check