### PR TITLE
Map the v6.4.3 patch line to release/v6.4

### DIFF
--- a/docs/release-control/control_plane.json
+++ b/docs/release-control/control_plane.json
@@ -19,6 +19,11 @@
       "stable_branch": "release/v6.3.2"
     },
     {
+      "version_prefix": "6.4.3",
+      "prerelease_branch": "release/v6.4",
+      "stable_branch": "release/v6.4"
+    },
+    {
       "version_prefix": "6.5.",
       "prerelease_branch": "release/v6.5",
       "stable_branch": "release/v6.5"

--- a/docs/release-control/v6/internal/RELEASE_PROMOTION_POLICY.md
+++ b/docs/release-control/v6/internal/RELEASE_PROMOTION_POLICY.md
@@ -279,6 +279,14 @@ without the other lanes changing the candidate underneath it.
    v6.2.0, v6.3.0, and v6.4.0. They remain recorded and bounded; the train
    does not continue the practice. An exception requires active customer
    harm and is recorded in the release notes.
+7. The `v6.4.3` patch line predates the first train and is the first line
+   released under the train's branch rule. `release/v6.4` was created from
+   `main` at the exact-SHA-qualified commit `56e51e622e` on 2026-09-02 and is
+   declared in `control_plane.json` with the version prefix `6.4.3`, so the
+   release workflow refuses a `v6.4.3` dispatch from any other branch and a
+   moving `main` can no longer invalidate the compiler's exact-SHA binding
+   between dispatch and compilation, which is what failed run 33579042375.
+   Earlier `6.4.x` versions keep their historical `main` mapping.
 
 ## Paid Pro Artifact Lineage
 


### PR DESCRIPTION
## What changed

`docs/release-control/control_plane.json` declares `release/v6.4` as the prerelease and stable branch for the `6.4.3` version prefix, and `RELEASE_PROMOTION_POLICY.md` records why in the Release Train section. Earlier `6.4.x` versions keep their historical `main` mapping; the `6.5.` train mapping is unchanged.

## Why

The `v6.4.3-rc.1` dispatch from `main` (run 33579042375) failed in the compiler dispatch: `main` advanced one minute after the pipeline pinned its source SHA (#1828 merged at 01:22 UTC), so the compiler run's exact-SHA identity check correctly refused the moved head. With pull requests landing every few minutes, a candidate dispatched from `main` cannot hold its SHA for the minutes between prepare and compile. This is the case the delivery contract's branch-per-train rule exists for, applied to the patch line that predates the first train.

`release/v6.4` has been created from `main` at the exact-SHA-qualified commit 56e51e622e with this same commit on top, so the branch carries the mapping the workflow reads at dispatch time.

## What it answers

The `v6.4.3-rc.1` candidate (patch for #1815, #1820, #1753). No product code changes.

## Evidence

- `python3 scripts/release_control/control_plane.py --branch-for-version 6.4.3-rc.1` → `release/v6.4`; `6.4.2` → `main`; `6.5.0-rc.1` → `release/v6.5`.
- `control_plane_audit_test` passes.
- Run 33579042375: `Compiler workflow identity or result verification failed` with the compiler run's head 419a368323 against source 56e51e622e.
