### PR TITLE
Treat Unraid fsType auto as slot config, not membership evidence

### DIFF
--- a/internal/hostagent/unraid.go
+++ b/internal/hostagent/unraid.go
@@ -521,11 +521,13 @@ func isUnraidEmptySlot(disk agentshost.UnraidDisk) bool {
 	}
 	// Unraid names every configured slot (for example disk6 or parity2), even
 	// when it has never been assigned. A slot label is therefore topology, not
-	// membership evidence. Preserve DISK_NP members only when native identity,
-	// device, filesystem, or size evidence shows that a disk was assigned.
+	// membership evidence, and the default fsType "auto" on unassigned slots
+	// is configuration, not evidence either. Preserve DISK_NP members only
+	// when native identity, device, filesystem, or size evidence shows that a
+	// disk was assigned.
 	return strings.TrimSpace(disk.Device) == "" &&
 		!unraidstatus.HasMeaningfulIdentity(disk.Model, disk.Serial) &&
-		strings.TrimSpace(disk.Filesystem) == "" &&
+		!unraidstatus.HasFilesystemEvidence(disk.Filesystem) &&
 		disk.SizeBytes == 0
 }
 

--- a/internal/hostagent/unraid_test.go
+++ b/internal/hostagent/unraid_test.go
@@ -154,6 +154,7 @@ diskNumber.5=5
 diskName.5=disk5
 diskSize.5=0
 diskId.5=ata-_
+diskFsType.5=auto
 rdevStatus.5=DISK_NP
 rdevName.5=
 rdevId.5=ata-_
@@ -185,6 +186,7 @@ mdNumMissing=1
 diskName.6=disk6
 diskSize.6=0
 diskId.6=ata-_
+diskFsType.6=auto
 rdevStatus.6=DISK_NP_MISSING
 rdevName.6=
 rdevId.6=ata-_
@@ -282,10 +284,10 @@ fsUsed="166957852"
 idx="6"
 name="disk6"
 device=""
-id="ata-_"
 size="0"
 status="DISK_NP"
 type="Data"
+fsType="auto"
 ["parity2"]
 idx="29"
 name="parity2"
@@ -294,6 +296,7 @@ id="ata-_"
 size="0"
 status="DISK_NP_DSBL"
 type="Parity"
+fsType="auto"
 `
 
 	disks := parseUnraidDisksINI(input)

--- a/internal/monitoring/monitor_agents.go
+++ b/internal/monitoring/monitor_agents.go
@@ -4147,7 +4147,7 @@ func isLegacyUnraidEmptySlot(disk agentshost.UnraidDisk, normalizedStatus string
 	}
 	return strings.TrimSpace(disk.Device) == "" &&
 		!unraidstatus.HasMeaningfulIdentity(disk.Model, disk.Serial) &&
-		strings.TrimSpace(disk.Filesystem) == "" &&
+		!unraidstatus.HasFilesystemEvidence(disk.Filesystem) &&
 		disk.SizeBytes == 0
 }
 

--- a/internal/monitoring/monitor_host_agents_test.go
+++ b/internal/monitoring/monitor_host_agents_test.go
@@ -2589,6 +2589,7 @@ func TestApplyHostReportFiltersLegacyUnraidEmptySlots(t *testing.T) {
 				{Name: "parity", Device: "/dev/sdb", Role: "parity", RawStatus: "DISK_OK", SizeBytes: 5860522532},
 				{Name: "disk1", Device: "/dev/sde", Role: "data", RawStatus: "DISK_OK", SizeBytes: 5860522532},
 				{Name: "disk6", Role: "data", RawStatus: "DISK_NP", Model: "ata -", Serial: "ata-_", Slot: 6},
+				{Name: "disk7", Role: "data", RawStatus: "DISK_NP", Filesystem: "auto", Slot: 7},
 				{Name: "parity2", Role: "parity", RawStatus: "DISK_NP_DSBL", Model: "ata -", Serial: "ata-_", Slot: 29},
 			},
 		},

--- a/internal/storagehealth/topology.go
+++ b/internal/storagehealth/topology.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/rcourtman/pulse-go-rewrite/internal/models"
+	unraidstatus "github.com/rcourtman/pulse-go-rewrite/internal/unraid"
 )
 
 func AssessHostRAIDArray(array models.HostRAIDArray) Assessment {
@@ -346,13 +347,16 @@ func unraidDiskStateCounts(storage models.HostUnraidStorage) (disabled, invalid,
 func isUnraidEmptySlot(disk models.HostUnraidDisk) bool {
 	rawStatus := strings.ToUpper(strings.TrimSpace(disk.RawStatus))
 	status := strings.ToLower(strings.TrimSpace(disk.Status))
+	if unraidstatus.IsExplicitMissingMember(rawStatus) {
+		return false
+	}
 	if !strings.Contains(rawStatus, "DISK_NP") && status != "missing" {
 		return false
 	}
 	return strings.TrimSpace(disk.Device) == "" &&
 		strings.TrimSpace(disk.Model) == "" &&
 		strings.TrimSpace(disk.Serial) == "" &&
-		strings.TrimSpace(disk.Filesystem) == "" &&
+		!unraidstatus.HasFilesystemEvidence(disk.Filesystem) &&
 		disk.SizeBytes == 0
 }
 

--- a/internal/storagehealth/topology_test.go
+++ b/internal/storagehealth/topology_test.go
@@ -237,7 +237,8 @@ func TestAssessUnraidStorageTreatsEmptyNoPresentSlotsAsUnprotected(t *testing.T)
 			{Name: "parity", Role: "parity", Status: "missing", RawStatus: "DISK_NP_DSBL"},
 			{Name: "md1p1", Device: "/dev/sde", Status: "online", RawStatus: "DISK_OK", SizeBytes: 5860522532},
 			{Name: "disk5", Role: "data", Status: "missing", RawStatus: "DISK_NP", Slot: 5},
-			{Name: "parity2", Role: "parity", Status: "missing", RawStatus: "DISK_NP_DSBL", Slot: 29},
+			{Name: "disk6", Role: "data", Status: "missing", RawStatus: "DISK_NP", Filesystem: "auto", Slot: 6},
+			{Name: "parity2", Role: "parity", Status: "missing", RawStatus: "DISK_NP_DSBL", Filesystem: "auto", Slot: 29},
 		},
 	})
 
@@ -279,6 +280,27 @@ func TestAssessUnraidStorageUsesDiskStatusesOverAggregateCounters(t *testing.T) 
 			t.Fatalf("unexpected aggregate-count reason when structured disk state is healthy: %+v", assessment.Reasons)
 		}
 	}
+}
+
+func TestAssessUnraidStoragePreservesExplicitMissingMemberWithoutIdentity(t *testing.T) {
+	assessment := AssessUnraidStorage(models.HostUnraidStorage{
+		ArrayStarted: true,
+		Disks: []models.HostUnraidDisk{
+			{Name: "parity", Role: "parity", Status: "online"},
+			{Name: "disk1", Role: "data", Status: "online"},
+			{Name: "disk2", Role: "data", Status: "missing", RawStatus: "DISK_NP_MISSING", Filesystem: "auto"},
+		},
+	})
+
+	if assessment.Level != RiskCritical {
+		t.Fatalf("Level = %q, want %q", assessment.Level, RiskCritical)
+	}
+	for _, reason := range assessment.Reasons {
+		if reason.Code == "unraid_missing_disks" {
+			return
+		}
+	}
+	t.Fatalf("explicit missing member without identity was not preserved: %+v", assessment.Reasons)
 }
 
 func TestAssessUnraidStoragePreservesGenuineStructuredMissingDisk(t *testing.T) {

--- a/internal/unraid/status.go
+++ b/internal/unraid/status.go
@@ -37,3 +37,16 @@ func HasMeaningfulIdentity(model, serial string) bool {
 func IsExplicitMissingMember(rawStatus string) bool {
 	return strings.EqualFold(strings.TrimSpace(rawStatus), "DISK_NP_MISSING")
 }
+
+// HasFilesystemEvidence reports whether a slot's filesystem value shows that a
+// disk was assigned. Unraid seeds every configured slot with fsType "auto",
+// including slots that have never held a device, so "auto" is slot
+// configuration rather than membership evidence.
+func HasFilesystemEvidence(filesystem string) bool {
+	switch strings.ToLower(strings.TrimSpace(filesystem)) {
+	case "", "auto":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/unraid/status_test.go
+++ b/internal/unraid/status_test.go
@@ -35,3 +35,26 @@ func TestIsExplicitMissingMember(t *testing.T) {
 		}
 	}
 }
+
+func TestHasFilesystemEvidence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{input: "", want: false},
+		{input: "  ", want: false},
+		{input: "auto", want: false},
+		{input: " AUTO ", want: false},
+		{input: "xfs", want: true},
+		{input: "luks:xfs", want: true},
+		{input: "btrfs", want: true},
+	}
+
+	for _, test := range tests {
+		if got := HasFilesystemEvidence(test.input); got != test.want {
+			t.Errorf("HasFilesystemEvidence(%q) = %v, want %v", test.input, got, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Unraid seeds every configured slot with fsType="auto", including slots that have never held a device. The empty-slot filters required an empty filesystem string, so a partially populated array kept reporting every unassigned DISK_NP slot as a missing member and raised a false critical unraid_missing_disks alert even after the identity sentinel fix.

Shares one HasFilesystemEvidence helper across agent collection, legacy server ingest, and storage-health assessment, and keeps Unraid's explicit DISK_NP_MISSING status authoritative in the assessment path. Regression tests mirror the reporter's v6.4.1 payload and fail without the fix.

Refs #1788