### PR TITLE
Capture the metrics startup hook per store to end a test flake

### DIFF
--- a/pkg/metrics/store.go
+++ b/pkg/metrics/store.go
@@ -211,6 +211,10 @@ type Store struct {
 	identityMigrationPending   atomic.Bool
 	commercialRetentionSeconds atomic.Int64
 	commercialPurgeEligibleAt  atomic.Int64
+
+	// startupHook is captured once at construction so a store that outlives
+	// the test that built it never invokes a later test's hook.
+	startupHook func()
 }
 
 // SetCommercialHistoryRetention applies a delayed commercial ceiling to the
@@ -303,6 +307,7 @@ func NewStore(config StoreConfig) (*Store, error) {
 		stopCh:            make(chan struct{}),
 		doneCh:            make(chan struct{}),
 		maintenanceDoneCh: make(chan struct{}),
+		startupHook:       startupMaintenanceHook,
 	}
 
 	// Initialize schema
@@ -883,8 +888,8 @@ func (s *Store) WaitForMaintenance(timeout time.Duration) error {
 
 func (s *Store) runStartupMaintenance() {
 	start := time.Now()
-	if startupMaintenanceHook != nil {
-		startupMaintenanceHook()
+	if s.startupHook != nil {
+		s.startupHook()
 	}
 
 	if s.identityMigrationPending.Swap(false) {

--- a/pkg/metrics/store_additional_test.go
+++ b/pkg/metrics/store_additional_test.go
@@ -617,12 +617,12 @@ func TestStoreFlushMakesQueuedWritesVisible(t *testing.T) {
 
 func TestNewStoreDefersStartupMaintenance(t *testing.T) {
 	previousHook := startupMaintenanceHook
-	defer func() {
-		startupMaintenanceHook = previousHook
-	}()
 
+	// The hook parks the maintenance worker before any startup work runs, so
+	// startup maintenance cannot complete until the test releases it.
 	started := make(chan struct{})
 	release := make(chan struct{})
+	var releaseOnce sync.Once
 	startupMaintenanceHook = func() {
 		close(started)
 		<-release
@@ -642,24 +642,28 @@ func TestNewStoreDefersStartupMaintenance(t *testing.T) {
 		close(done)
 	}()
 
-	select {
-	case <-done:
-	case <-time.After(200 * time.Millisecond):
-		t.Fatal("NewStore blocked on startup maintenance")
-	}
+	// Release the worker and wait for NewStore before restoring the hook, so a
+	// failed run never leaks a parked store into the next test.
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(release) })
+		<-done
+		if store != nil {
+			store.Close()
+		}
+		startupMaintenanceHook = previousHook
+	})
 
+	// Deferral is proven by ordering, not by a wall-clock bound: NewStore must
+	// return while the worker is still parked in the hook. If startup
+	// maintenance ever ran inline again, this receive would block until the
+	// package test timeout instead of flaking on a slow CI disk.
+	<-started
+	<-done
 	if err != nil {
 		t.Fatalf("NewStore returned error: %v", err)
 	}
 
-	select {
-	case <-started:
-	case <-time.After(time.Second):
-		t.Fatal("startup maintenance was not scheduled")
-	}
-
-	close(release)
-	defer store.Close()
+	releaseOnce.Do(func() { close(release) })
 }
 
 func TestStoreWaitForMaintenanceWaitsForQueuedStartupWork(t *testing.T) {


### PR DESCRIPTION
TestNewStoreDefersStartupMaintenance bounded NewStore at 200ms. On a
slow CI disk that bound tripped, the test failed, and its NewStore
goroutine kept running: the maintenance worker it spawned read the
package-level startupMaintenanceHook after the next test had installed
its own closure, closed that test's started channel a second time, and
panicked the whole rest-1 shard (run 33630289317, attempt 1).

Capture the hook once in NewStore so a store can only ever call the
hook that was installed when it was built. Prove deferral by ordering
instead of wall clock: the hook parks the worker, and NewStore must
return while it is parked. A regression to inline maintenance now
blocks that receive until the package timeout instead of flaking.
Cleanup releases the worker and waits for NewStore before restoring
the hook, so a failed run cannot leak a parked store either.