### PR TITLE
Record the Patrol investigation rate as an invalid metric

### DIFF
--- a/docs/release-control/v6/internal/status.json
+++ b/docs/release-control/v6/internal/status.json
@@ -10128,6 +10128,48 @@
           "kind": "file"
         }
       ]
+    },
+    {
+      "id": "patrol-investigation-rate-metric-invalid",
+      "summary": "The Patrol investigation rate (pulse_intelligence_patrol_investigations_30d over pulse_intelligence_patrol_new_findings_30d), which TELEMETRY_SIGNALS.md instructs every reader to report, is not a rate and must not be trended. Four independent reasons, all verified in pkg/server/telemetry_pulse_intelligence.go: the denominator sums run.NewFindings over history.Runs, which SavePatrolRunHistory caps at MaxPatrolRunHistory (100), so it covers at most the last hundred runs rather than thirty days and silently under-reports for any install patrolling faster than that (355 of 449 Patrol-enabled installs in the 6.4 upgrade cohort on 2026-09-03); the numerator instead scans the current findings store and counts surviving finding records investigated in-window, including findings created before it, which is how the paid cohort read 128.57 percent in the week to 2026-08-25; the populations are disjoint because Finding.ShouldInvestigate returns false at monitor autonomy and effective autonomy is licence-gated, so free installs produced 4384 findings and 1 investigation (0.02 percent) in the week to 2026-09-03 while 67 paid installs produced 242; and only 29 clean installs reported any investigation at all, one of which swung the fleet total by 38. The three-week decline that prompted this (7.2 to 5.0 percent) is composition, not regression: the rate is flat in version-stable installs (3.48, 3.39, 3.78), fleet investigations rose once that single install is excluded (170, 213, 225), finding-detection code is identical between v6.3.2 and v6.4.1, and the patrol interval is unchanged at 360 minutes across 6.1 through 6.4. The reported run growth is likewise the 63c40ebe5e daily tally back-filling, not more patrolling. This also corrects the telemetry inference in patrol-findings-hygiene-attention-noise: findings are not mostly 'seen and ignored', they are raised on installs that are licence-gated out of investigating at all, which leaves that gap's independently evidenced UX work (discussions 1623 and 1699) standing on its own footing. Two defects follow: new_findings_30d saturates on the very history cap that 63c40ebe5e fixed for runs_30d in the same function, needing a per-day findings tally alongside DailyRuns; and the blessed doc tells every reader to compute the invalid ratio. The real signal the ratio was hiding is that paid Patrol installs fell from 76 to 67 while free Patrol grew from 888 to 962.",
+      "owner": "project-owner",
+      "status": "triaged",
+      "recorded_at": "2026-09-03",
+      "lane_ids": [
+        "L6"
+      ],
+      "subsystem_ids": [
+        "patrol-intelligence"
+      ],
+      "proposed_resolution": "lane-expansion",
+      "coverage_impact": 2,
+      "evidence": [
+        {
+          "repo": "pulse",
+          "path": "internal/ai/findings.go",
+          "kind": "file"
+        },
+        {
+          "repo": "pulse",
+          "path": "internal/ai/patrol.go",
+          "kind": "file"
+        },
+        {
+          "repo": "pulse",
+          "path": "pkg/server/telemetry_pulse_intelligence.go",
+          "kind": "file"
+        },
+        {
+          "repo": "pulse",
+          "path": "pkg/server/telemetry_pulse_intelligence_test.go",
+          "kind": "file"
+        },
+        {
+          "repo": "pulse-pro",
+          "path": "docs/TELEMETRY_SIGNALS.md",
+          "kind": "file"
+        }
+      ]
     }
   ],
   "candidate_lanes": [

--- a/pkg/server/telemetry_pulse_intelligence_test.go
+++ b/pkg/server/telemetry_pulse_intelligence_test.go
@@ -1123,6 +1123,53 @@ func TestApplyPulseIntelligencePatrolRunSnapshotIgnoresHistoryCap(t *testing.T) 
 	}
 }
 
+// PulseIntelligencePatrolNewFindings30d is summed over the retained run list,
+// which SavePatrolRunHistory caps at MaxPatrolRunHistory, while
+// PulseIntelligencePatrolRuns30d rides the uncapped daily tally that
+// TestApplyPulseIntelligencePatrolRunSnapshotIgnoresHistoryCap pins. An
+// install patrolling faster than the cap therefore reports every run but only
+// the findings from the most recent hundred, so the two counters cover
+// different spans and no ratio between findings and any other counter is a
+// rate. Pinned so the asymmetry stays a known bound rather than a silent one;
+// see coverage gap patrol-investigation-rate-metric-invalid.
+func TestApplyPulseIntelligencePatrolRunSnapshotTruncatesNewFindingsAtHistoryCap(t *testing.T) {
+	persistence := config.NewConfigPersistence(t.TempDir())
+	now := time.Now().UTC()
+	since := now.AddDate(0, 0, -30)
+
+	const historyCap = 100
+	total := 0
+	runs := make([]config.PatrolRunRecord, 0, historyCap)
+	for at := now.AddDate(0, 0, -2); at.Before(now); at = at.Add(10 * time.Minute) {
+		runs = append([]config.PatrolRunRecord{{
+			ID:          at.Format(time.RFC3339Nano),
+			StartedAt:   at,
+			CompletedAt: at,
+			NewFindings: 1,
+		}}, runs...)
+		if len(runs) > historyCap {
+			runs = runs[:historyCap]
+		}
+		total++
+		if err := persistence.SavePatrolRunHistory(runs); err != nil {
+			t.Fatalf("SavePatrolRunHistory: %v", err)
+		}
+	}
+	if total <= historyCap {
+		t.Fatalf("test needs more runs than the cap, got %d", total)
+	}
+
+	snap := &telemetry.Snapshot{}
+	applyPulseIntelligencePatrolRunSnapshot(snap, persistence, since)
+	if snap.PulseIntelligencePatrolRuns30d != total {
+		t.Fatalf("PulseIntelligencePatrolRuns30d = %d, want %d", snap.PulseIntelligencePatrolRuns30d, total)
+	}
+	if snap.PulseIntelligencePatrolNewFindings30d != historyCap {
+		t.Fatalf("PulseIntelligencePatrolNewFindings30d = %d, want %d (one per retained run, not one per run in the window)",
+			snap.PulseIntelligencePatrolNewFindings30d, historyCap)
+	}
+}
+
 // The Patrol blocked cause must ride the router snapshot into the outbound
 // ping unchanged, so a blocked install is distinguishable in the fleet from
 // one whose Patrol runs and finds nothing.


### PR DESCRIPTION
A three-week decline in investigations/new_findings (7.2% to 5.0%) looked
like a Patrol regression. It is not one. The ratio is not a rate at all:
the two counters come from different stores, cover different spans, and
are drawn from populations that barely overlap.

new_findings_30d sums run.NewFindings over history.Runs, which
SavePatrolRunHistory caps at MaxPatrolRunHistory, so it covers at most the
last hundred runs rather than thirty days. investigations_30d instead
scans the current findings store and counts surviving finding records
investigated in-window, including findings created before it, which is how
the paid cohort read 128.57% in the week to 2026-08-25. Finding
ShouldInvestigate returns false at monitor autonomy and effective autonomy
is licence-gated, so free installs produced 4384 findings and 1
investigation while 67 paid installs produced 242.

The decline was composition: flat in version-stable installs, and fleet
investigations rose once the single install that swung the total by 38 was
excluded. Finding-detection code is identical between v6.3.2 and v6.4.1.

The new test pins the asymmetry behind the bad denominator. Its twin
already asserts that runs_30d ignores the history cap after 63c40ebe5e;
nothing asserted that the findings loop immediately below it does not, so
the truncation could regress or be mistaken for a thirty-day total
unnoticed. Fixing it needs a per-day findings tally alongside DailyRuns,
which the coverage gap tracks as its own slice.
