### PR TITLE
Order the Patrol HTTP observer test against its health-lease write

### DIFF
--- a/internal/ai/patrol_observer_runtime_test.go
+++ b/internal/ai/patrol_observer_runtime_test.go
@@ -433,8 +433,24 @@ func TestPatrolHTTPJSONObserverUsesScopedDiscoveryOriginSecretReferenceAndWakes(
 	case <-time.After(3 * time.Second):
 		t.Fatal("HTTP JSON observer did not execute")
 	}
-	deadline := time.Now().Add(2 * time.Second)
-	for tm.GetPendingCount() != 1 && time.Now().Before(deadline) {
+	// The HTTP sample runs on its own goroutine and persists the health lease
+	// strictly after it queues the wake, so the lease is the one side effect
+	// that orders the whole sample against these assertions. Gating on the wake
+	// instead let a loaded runner read a half-applied sample: a queued trigger
+	// with a still-nil lease, reported as degraded/observer_health_unknown.
+	// Coverage is evaluated at a fixed instant derived from the sample time so
+	// the verdict never depends on how long the goroutine took to get there.
+	evaluatedAt := now.Add(2 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
+	var installed PatrolObjective
+	for {
+		installed, _ = store.Get(objective.ID, evaluatedAt)
+		if installed.Observer != nil && installed.Observer.ValidUntil != nil {
+			break
+		}
+		if !time.Now().Before(deadline) {
+			t.Fatalf("HTTP JSON observer never persisted a health lease: %+v", installed.Observer)
+		}
 		time.Sleep(5 * time.Millisecond)
 	}
 	if tm.GetPendingCount() != 1 {
@@ -444,8 +460,7 @@ func TestPatrolHTTPJSONObserverUsesScopedDiscoveryOriginSecretReferenceAndWakes(
 	if queued.ObjectiveContext == nil || !strings.Contains(queued.ObjectiveContext.Evidence, "buffering_sessions") || !strings.Contains(queued.ObjectiveContext.Evidence, "actual_1") {
 		t.Fatalf("HTTP JSON objective evidence = %+v", queued.ObjectiveContext)
 	}
-	installed, _ := store.Get(objective.ID, time.Now().UTC())
-	if installed.Observer == nil || installed.Observer.State != PatrolObserverInstalled || installed.Coverage.State != PatrolObjectiveCovered {
+	if installed.Observer.State != PatrolObserverInstalled || installed.Coverage.State != PatrolObjectiveCovered || installed.Coverage.ReasonCode != "observer_healthy" {
 		t.Fatalf("HTTP observer coverage = %+v / %+v", installed.Observer, installed.Coverage)
 	}
 }


### PR DESCRIPTION
`TestPatrolHTTPJSONObserverUsesScopedDiscoveryOriginSecretReferenceAndWakes` is flaky in CI and blocked the required "Backend tests (rest-0)" check on an unrelated PR (#1884, run 33846941086).

## Cause

The HTTP JSON observer samples on its own goroutine. That goroutine queues the wake (`finalizeObjectiveObserverSample` → `TriggerPatrol`) **before** it persists the health lease (`RefreshObserverHealthBatch`). The test gated on the wake — polling `tm.GetPendingCount() == 1` — and then read coverage immediately, so a runner that descheduled the goroutine in that window saw a half-applied sample: an installed observer with a nil `ValidUntil`, which `derivePatrolObjectiveCoverage` reports as `degraded` / `observer_health_unknown`.

Not a regression — a test asserting on an intermediate state of async work.

## Fix

Gate on the lease instead. It is the sample's last state-visible action and it goes through the store mutex, so observing it establishes happens-before with every earlier side effect of that sample, the queued trigger included. Coverage is also evaluated at a fixed instant derived from the sample time rather than `time.Now()`, so the verdict no longer depends on elapsed real time.

## Verification

A build overlay inserting a 150ms delay between the wake and the lease write models the loaded runner:

| run | result |
|---|---|
| old test + widened window | **fails 5/5**, `ValidUntil:<nil>`, `degraded`/`observer_health_unknown`, CreatedAt/UpdatedAt 1s apart — the exact CI symptom |
| new test + widened window | passes 20/20 |
| new test + widened window, `GOMAXPROCS=1 -race` | passes 50/50 |
| new test, unmodified runtime, `-race -count=300` | passes |
| full `./internal/ai` package, `-race` | passes |