### PR TITLE
Stop test binaries reporting to the production telemetry endpoint

### DIFF
--- a/docs/release-control/v6/internal/subsystems/security-privacy.md
+++ b/docs/release-control/v6/internal/subsystems/security-privacy.md
@@ -445,6 +445,15 @@ the `white_label` branding entitlement.
    runs per event so runtime mock toggles take effect immediately — because a
    mock-mode snapshot describes the synthetic fixture fleet rather than a real
    installation.
+   A Go test binary is the same kind of suppression boundary: while
+   `testing.Testing()` reports true, `internal/telemetry` must not post to the
+   production receiver on any path, including the synchronous service-health
+   failure event `pkg/server.Run` sends from its deferred handler. A test that
+   boots the real server runs against a throwaway data directory, so it mints
+   a fresh install ID on every run and the receiver counts it as a distinct
+   live installation. The guard compares the resolved endpoint against
+   `productionPingEndpoint`, so tests that redirect `pingEndpoint` at a local
+   server keep asserting on real ping content.
    Pulse Intelligence external-agent/MCP telemetry may expose only content-free
    adapter-origin usage and capability-class counters for context, event
    stream, provisioning, operator state, finding, and action requests. It must

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -96,6 +96,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -106,9 +107,16 @@ import (
 
 // pingEndpoint is the URL that receives outbound usage telemetry pings.
 // It is a var (not const) so that tests can redirect it to a local server.
-var pingEndpoint = "https://license.pulserelay.pro/v1/telemetry/ping"
+// productionPingEndpoint is the live receiver for outbound usage telemetry.
+const productionPingEndpoint = "https://license.pulserelay.pro/v1/telemetry/ping"
+
+var pingEndpoint = productionPingEndpoint
 
 var errInstallIDUnavailable = errors.New("telemetry install id unavailable")
+
+// errProductionEndpointUnderTest reports a ping suppressed because a test
+// binary tried to reach the live receiver.
+var errProductionEndpointUnderTest = errors.New("telemetry: refusing to post to the production endpoint from a test binary")
 
 const (
 	// heartbeatInterval is the base interval between daily pings.
@@ -1657,6 +1665,15 @@ func buildPingAt(cfg Config, event string, now time.Time) (Ping, error) {
 // send posts a ping to the telemetry endpoint. Errors are observable in debug
 // logs but never affect normal Pulse operation.
 func send(ctx context.Context, ping Ping) error {
+	// A test binary is not a real installation. Any test that boots the real
+	// server (pkg/server.Run and anything like it) runs against a throwaway
+	// data directory, so it mints a fresh install ID per run and would be
+	// counted as a distinct live install. Telemetry's own tests redirect
+	// pingEndpoint at a local server and are unaffected by this guard.
+	if testing.Testing() && pingEndpoint == productionPingEndpoint {
+		return errProductionEndpointUnderTest
+	}
+
 	body, err := json.Marshal(ping)
 	if err != nil {
 		return err

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -1322,5 +1323,57 @@ func TestBuildPingCarriesNodeTestCounts(t *testing.T) {
 	}
 	if ping.NodeTestFailures30d != 4 {
 		t.Fatalf("node_test_failures_30d = %d, want 4", ping.NodeTestFailures30d)
+	}
+}
+
+// The production telemetry receiver must be unreachable from a Go test binary.
+// A test that boots the real server runs against a throwaway data directory,
+// so it mints a fresh install ID on every run and lands at the receiver as a
+// distinct live installation.
+func TestSendRefusesProductionEndpointUnderTest(t *testing.T) {
+	if pingEndpoint != productionPingEndpoint {
+		t.Fatalf("pingEndpoint = %q, want the production endpoint by default", pingEndpoint)
+	}
+
+	err := send(context.Background(), Ping{Event: "startup"})
+	if !errors.Is(err, errProductionEndpointUnderTest) {
+		t.Fatalf("send() to the production endpoint = %v, want errProductionEndpointUnderTest", err)
+	}
+}
+
+// SendServiceHealthEvent is the path pkg/server.Run takes when startup fails,
+// and it sends synchronously rather than after the startup delay, which is why
+// the failing server tests reported and the passing ones did not.
+func TestSendServiceHealthEventRefusesProductionEndpointUnderTest(t *testing.T) {
+	cfg := Config{Version: "test-version", DataDir: t.TempDir(), Enabled: true}
+
+	err := SendServiceHealthEvent(context.Background(), cfg, "startup", ServiceHealthObservation{
+		Observed:        true,
+		FailureCategory: ServiceHealthFailureListener,
+	})
+	if !errors.Is(err, errProductionEndpointUnderTest) {
+		t.Fatalf("SendServiceHealthEvent() = %v, want errProductionEndpointUnderTest", err)
+	}
+}
+
+// A redirected endpoint is how telemetry's own tests assert on ping content,
+// so the guard must not block it.
+func TestSendAllowsRedirectedEndpointUnderTest(t *testing.T) {
+	var received atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	origEndpoint := pingEndpoint
+	pingEndpoint = ts.URL
+	defer func() { pingEndpoint = origEndpoint }()
+
+	if err := send(context.Background(), Ping{Event: "startup"}); err != nil {
+		t.Fatalf("send() to a redirected endpoint: %v", err)
+	}
+	if got := received.Load(); got != 1 {
+		t.Fatalf("redirected endpoint received %d pings, want 1", got)
 	}
 }


### PR DESCRIPTION
Backport of the main-branch guard. pkg/server tests boot the real server
through Run() with the version literal "test-version", which normalizes to
0.0.0-test-version, and each test runs against its own t.TempDir(), so
every run mints a fresh install ID. The service-health failure reporter
sends synchronously from a deferred handler as soon as Run() returns an
error, so any test exercising a startup failure posts one ping.

This line still emitted after main was fixed: release-line lane work runs
pkg/server tests on this branch, and those pings arrive with the old
version classifier too, so they land mislabelled as ordinary prereleases
and re-contaminate install-population reads that were just corrected.

send() now refuses the production endpoint whenever testing.Testing()
reports true. The check compares against productionPingEndpoint, so
telemetry's own tests keep asserting on ping content through a redirected
endpoint. Verified on this branch: three runs of the failing-startup
tests, zero pings received.
