### PR TITLE
Give the Frontend job room for the npm audit retries

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,7 +121,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 25
+    # The two npm audit steps retry through registry outages (they burned
+    # 14m34s on 2026-09-04), which no longer fits a 25 minute budget: the job
+    # was cancelled mid type-check with all 1183 test files already passing.
+    timeout-minutes: 40
     env:
       FRONTEND_DIR: frontend-modern
 


### PR DESCRIPTION
The npm audit hardening added on 2026-09-04 retries through registry
outages instead of failing on the first 503. That is the right behaviour,
but the two audit steps then took 10m56s and 3m36s, and with roughly 11
minutes of install, lint, 1183 test files and type-check behind them the
job no longer fits timeout-minutes 25. It was cancelled 31 seconds into
type-check with every test already passing, which reads as a failed
required check and blocks every pull request.

Raising the budget to 40 leaves headroom for a slow audit without
weakening any gate. Bounding the retry itself is the better long-term
answer, but that trades delivery availability against audit coverage
during an outage and is a security-posture decision rather than a CI
tuning one.

Contract-Neutral: CI job time budget only; no dependency-security or contract behaviour changes
