### PR TITLE
Leave release cadence to maintainer judgment

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -216,7 +216,8 @@ jobs:
   backend:
     name: Backend tests (${{ matrix.shard }})
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # Expand every required shard even for documentation-only changes. A
+    # job-level condition skips expansion and leaves the named checks pending.
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     strategy:
@@ -227,12 +228,18 @@ jobs:
         shard: [api, rest-0, rest-1]
 
     steps:
+      - name: Report documentation-only change
+        if: needs.changes.outputs.code != 'true'
+        run: echo "No backend code changed. Tests are not required for this shard."
+
       - name: Checkout repository
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up Go
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
@@ -243,12 +250,14 @@ jobs:
       # without the ~5 minute frontend build; the real bundle is built and
       # size-gated by the frontend job, and release artifacts always build it.
       - name: Provide frontend embed stub
+        if: needs.changes.outputs.code == 'true'
         run: |
           mkdir -p internal/api/frontend-modern/dist
           [ -f internal/api/frontend-modern/dist/index.html ] || \
             printf '<!doctype html><title>ci embed stub</title>\n' > internal/api/frontend-modern/dist/index.html
 
       - name: Go unit tests (shard ${{ matrix.shard }})
+        if: needs.changes.outputs.code == 'true'
         env:
           PULSE_DATA_DIR: /tmp/pulse-test-data
         # internal/api alone takes ~22m under -race on a fast machine since

--- a/docs/release-control/v6/internal/RELEASE_PROMOTION_POLICY.md
+++ b/docs/release-control/v6/internal/RELEASE_PROMOTION_POLICY.md
@@ -241,23 +241,18 @@ stable release is an exact soaked candidate rather than the tip of a branch
 that keeps moving, and so that the always-running maintainer can release
 without the other lanes changing the candidate underneath it.
 
-1. A minor train runs every two weeks. The first candidate is cut on a
-   fixed day and time, Tuesday 09:00 Europe/London, and general availability
-   is the Tuesday one week later; the next train's candidate is cut the
-   Tuesday after that. The first train is v6.5.0: `v6.5.0-rc.1` on
-   2026-09-08, general availability on 2026-09-15, then `v6.6.0-rc.1` on
-   2026-09-22. The cadence follows measured velocity, not preference: at the
-   70 to 150 commits a day `main` received in the week before adoption, a
-   four-week train would put two to four thousand commits into every user
-   upgrade, and a two-week train halves that while keeping a full seven day
-   soak. The release steward reviews the cadence against velocity after
-   every third train and records the decision here.
+1. Founder intent, clarified on 2026-09-05: fast progress, with willingness
+   to use many betas before GA. Release scope, version, maturity and timing
+   belong to the maintainer's judgment from current evidence. The former
+   fixed v6.5 September 8/15 and v6.6 September 22 calendar is withdrawn.
+   The existing exact-candidate, source, soak and publication-authority
+   requirements still apply.
 2. Each train has its own branch, `release/v6.N`, created from `main` at cut
    time and declared in `docs/release-control/control_plane.json` so the
    release workflow refuses a dispatch from any other branch. `main` is never
-   frozen. A fix for something found in the candidate is backported to the
-   release branch through a pull request; each backport produces the next
-   `rc.N` and restarts the soak. After general availability the branch is
+   frozen. A fix for something found in a checkpoint is backported to the
+   release branch through a pull request. Each changed RC starts its own full soak; beta time never counts toward
+   stable promotion. After general availability the branch is
    the patch line for that train.
 3. General availability promotes the candidate's content. The resolver
    refuses a stable promotion whose tree differs from the promoted candidate

--- a/docs/release-control/v6/internal/status.json
+++ b/docs/release-control/v6/internal/status.json
@@ -9980,7 +9980,7 @@
     },
     {
       "id": "release-train-exact-candidate-promotion",
-      "summary": "Stable promotions built whatever the dispatch branch was at that second: the resolver checked that HEAD descends from the promoted RC but not that its content matches, so v6.4.0 shipped 64 changed files that v6.4.0-rc.12 never soaked, and every v6 version was mapped to main, which moves every few minutes under the autonomous maintainer. The release train needs a branch per train declared in the control plane, a resolver rule that refuses stable content beyond release metadata without a recorded hotfix reason, and a seven day soak for minor releases so the two-week cadence carries a real soak.",
+      "summary": "Stable promotions built whatever the dispatch branch was at that second: the resolver checked that HEAD descends from the promoted RC but not that its content matches, so v6.4.0 shipped 64 changed files that v6.4.0-rc.12 never soaked, and every v6 version was mapped to main, which moves every few minutes under the autonomous maintainer. The release train needs a branch per train declared in the control plane, a resolver rule that refuses stable content beyond release metadata without a recorded hotfix reason, and a seven day soak for minor releases. Founder direction on 2026-09-05 replaces the fixed minor calendar with maintainer-owned release judgment informed by the preference for fast progress and willingness to use many betas, while retaining exact-candidate, branch and clean-soak requirements.",
       "owner": "project-owner",
       "status": "triaged",
       "recorded_at": "2026-09-01",


### PR DESCRIPTION
The fixed September minor-release calendar treated an advisory schedule as a release decision. Replace it with the founder’s intent for fast progress and willingness to use many betas, leaving scope, version, maturity and timing to maintainer judgment. Existing exact-candidate, source, soak and approval requirements remain in force.

Required backend matrix checks now appear for documentation-only changes, with code-only setup and tests skipped at step level. Previously the job-level condition prevented the matrix from expanding and left required check names pending indefinitely.

Validation: 54 release policy tests passed. Status audit reported no current-target blockers. Workflow structure checks cover all three required shard names and both change classes. No release artifacts are published by this change.
