### PR TITLE
Prioritize dependable release delivery

### DIFF
--- a/docs/release-control/control_plane.json
+++ b/docs/release-control/control_plane.json
@@ -6,7 +6,7 @@
   "control_plane_doc": "docs/release-control/internal/CONTROL_PLANE.md",
   "control_plane_schema": "docs/release-control/control_plane.schema.json",
   "active_profile_id": "v6",
-  "active_target_id": "v6-product-lane-expansion",
+  "active_target_id": "v6-release-reliability",
   "legacy_release_lines": [
     {
       "version_prefix": "5.1.",
@@ -83,8 +83,17 @@
       "id": "v6-product-lane-expansion",
       "profile_id": "v6",
       "kind": "feature",
+      "status": "planned",
+      "summary": "Post-GA active development runs on main and promotes proactive Pulse Intelligence, policy-aware data governance, resource-change intelligence, action-governance, fleet-governance, agent-operable infrastructure onboarding, continuous discovery reconciliation, and agent-ready operations contract proof after the monitoring-first v6 floor; Patrol is the detection and investigation engine, Assistant is the contextual explanation, approval, and governed action surface, and agent-ready proof is API/CLI-first with MCP only as an adapter over canonical contracts. The planned product priority is a coherent Patrol-to-Assistant customer journey: explain the selected issue from current evidence, preserve governed approval and verification, and qualify useful outcomes for unhealthy services, backup or capacity risks, and supported VM or LXC actions before claiming broad Pulse Pro value.",
+      "completion_rule": "manual",
+      "proof_scope": "none"
+    },
+    {
+      "id": "v6-release-reliability",
+      "profile_id": "v6",
+      "kind": "maintenance",
       "status": "active",
-      "summary": "Post-GA active development runs on main and promotes proactive Pulse Intelligence, policy-aware data governance, resource-change intelligence, action-governance, fleet-governance, agent-operable infrastructure onboarding, continuous discovery reconciliation, and agent-ready operations contract proof after the monitoring-first v6 floor; Patrol is the detection and investigation engine, Assistant is the contextual explanation, approval, and governed action surface, and agent-ready proof is API/CLI-first with MCP only as an adapter over canonical contracts. The current product priority is a coherent Patrol-to-Assistant customer journey: explain the selected issue from current evidence, preserve governed approval and verification, and qualify useful outcomes for unhealthy services, backup or capacity risks, and supported VM or LXC actions before claiming broad Pulse Pro value.",
+      "summary": "Priority set on 10 September 2026: stability, consistent updates and fixing reported issues are the highest current objective, to rebuild user trust through dependable delivery. Prioritize resolving release blockers and verifying qualification, publication and customer delivery through the existing release process. Keep failed attempts owned through repair and verified recovery without repeated founder chasing. Release consistency remains unconfirmed until actual release and recovery evidence establishes dependable end-to-end delivery. A repaired component, passing source check or started retry does not establish this outcome. Feature expansion is not a current priority.",
       "completion_rule": "manual",
       "proof_scope": "none"
     }

--- a/internal/repoctl/canonical_development_protocol_test.go
+++ b/internal/repoctl/canonical_development_protocol_test.go
@@ -587,7 +587,7 @@ func TestReleaseControlPlaneFilesExist(t *testing.T) {
 	if !ok || activeTargetID == "" {
 		t.Fatalf("%s missing active_target_id", jsonRel)
 	}
-	if activeTargetID != "v6-rc-cut" && activeTargetID != "v6-rc-stabilization" && activeTargetID != "v6-ga-promotion" && activeTargetID != "v6-product-lane-expansion" {
+	if activeTargetID != "v6-rc-cut" && activeTargetID != "v6-rc-stabilization" && activeTargetID != "v6-ga-promotion" && activeTargetID != "v6-product-lane-expansion" && activeTargetID != "v6-release-reliability" {
 		t.Fatalf("%s has unexpected active_target_id %q", jsonRel, activeTargetID)
 	}
 
@@ -623,7 +623,7 @@ func TestReleaseControlPlaneFilesExist(t *testing.T) {
 		}
 	}
 
-	for _, requiredID := range []string{"v6-rc-cut", "v6-rc-stabilization", "v6-ga-promotion", "v6-product-lane-expansion"} {
+	for _, requiredID := range []string{"v6-rc-cut", "v6-rc-stabilization", "v6-ga-promotion", "v6-product-lane-expansion", "v6-release-reliability"} {
 		if _, ok := targetsByID[requiredID]; !ok {
 			t.Fatalf("%s missing target %q", jsonRel, requiredID)
 		}

--- a/scripts/release_control/release_promotion_policy_test.py
+++ b/scripts/release_control/release_promotion_policy_test.py
@@ -2670,7 +2670,7 @@ class ReleasePromotionPolicyTest(unittest.TestCase):
                 f"The active control-plane target is `{active_target_id}`, so stable or GA",
                 blocked,
             )
-        elif active_target_id == "v6-product-lane-expansion":
+        elif active_target_id in {"v6-product-lane-expansion", "v6-release-reliability"}:
             self.assertIn(
                 "The active control-plane target is `v6-ga-promotion`, so stable or GA",
                 blocked,

--- a/scripts/release_control/subsystem_lookup_test.py
+++ b/scripts/release_control/subsystem_lookup_test.py
@@ -127,7 +127,7 @@ class SubsystemLookupTest(unittest.TestCase):
         self.assertIsInstance(result["status_audit_errors"], list)
         self.assertIn(
             result["control_plane"]["active_target"]["id"],
-            {"v6-rc-cut", "v6-rc-stabilization", "v6-ga-promotion", "v6-product-lane-expansion"},
+            {"v6-rc-cut", "v6-rc-stabilization", "v6-ga-promotion", "v6-product-lane-expansion", "v6-release-reliability"},
         )
         self.assertEqual(result["scope"]["control_plane_repo"], "pulse")
         self.assertEqual(result["status_summary"]["lane_count"], 24)


### PR DESCRIPTION
Stability, consistent updates and fixing reported issues are the highest current priority, to rebuild user trust. Feature expansion is not a current priority. Keep release consistency explicitly unconfirmed until actual release and recovery evidence establishes dependable delivery.

Validation: control-plane entrypoint selects v6-release-reliability, targeted repository guardrail test and status and registry audits pass.
