### PR TITLE
Fix manual update freshness and unknown release dates

### DIFF
--- a/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
+++ b/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
@@ -3386,6 +3386,14 @@ Agent` secondary handoff against the live setup wizard instead of relying
 
 ## Current State
 
+### Manual update freshness
+
+Server update-check freshness is owned by internal/updates and its API adapter.
+The force query requests a new provider read only. It grants no agent update,
+installation or command-execution authority, and an available server update is
+not evidence that any agent was upgraded.
+
+
 ### Privileged helper framing and identities are architecture-safe
 
 The no-network helper rejects a framed allocation size that cannot include its

--- a/docs/release-control/v6/internal/subsystems/api-contracts.md
+++ b/docs/release-control/v6/internal/subsystems/api-contracts.md
@@ -4514,6 +4514,16 @@ auto-register mutation boundary.
 
 ## Current State
 
+### Manual update freshness
+
+GET /api/updates/check accepts an optional boolean force query alongside the
+existing channel selector. The handler rejects malformed or repeated force values,
+passes freshness explicitly to the manager and marks responses no-store. Manual
+checks send force=true without overriding the saved channel. UpdateInfo.releaseDate
+is optional when the provider has no publication date. Handler and client tests
+cover this transport contract.
+
+
 ### Attention flapping summary and finding alert-mirror fields
 
 `GET /api/ai/patrol/attention` items and `GET /api/ai/patrol/attention/{id}`

--- a/docs/release-control/v6/internal/subsystems/deployment-installability.md
+++ b/docs/release-control/v6/internal/subsystems/deployment-installability.md
@@ -2357,6 +2357,17 @@ artifact-selection behaviour.
 
 ## Current State
 
+### Manual update freshness
+
+Manual update checks carry explicit freshness to the update manager. They bypass
+its saved-channel cache and replace that cache only after a successful provider
+check. A forced provider failure cannot masquerade as a successful cached check.
+Background checks retain their cache policy. Unknown release dates are omitted
+from UpdateInfo JSON rather than encoded as the zero time. Targeted manager tests
+exercise stale-cache replacement and unknown/known date serialization. This
+contract does not install updates or establish release qualification.
+
+
 ### Candidate notes cover restored Proxmox node network details
 
 The current v6.4 candidate notes record that configured PVE node interface

--- a/docs/release-control/v6/internal/subsystems/frontend-primitives.md
+++ b/docs/release-control/v6/internal/subsystems/frontend-primitives.md
@@ -3360,6 +3360,21 @@ resolves late` in
 
 ## Current State
 
+### Manual update freshness
+
+The update panel has a dedicated proof route to `updatesPresentation.test.ts`,
+with exact-content browser verification still required for rendered changes.
+
+Check Now propagates explicit freshness through the shared update store and API
+client. A manual request arriving during a background check waits for it and then
+performs its own fresh read rather than returning early. A successful response records completion time, while failed refreshes
+retain the last successful result and its age. The settings release date uses the
+shared presentation helper, which omits absent, invalid and legacy zero timestamps.
+Cached update responses remain valid without a release date. Browser qualification
+covers the current settings route, pending/retry states, keyboard checks and date
+presentation at desktop, intermediate and narrow widths.
+
+
 ### Provider tabs use compact canonical evidence during route hydration
 
 Evidence-gated provider tabs consume the unified-resource owner's

--- a/docs/release-control/v6/internal/subsystems/registry.json
+++ b/docs/release-control/v6/internal/subsystems/registry.json
@@ -668,14 +668,14 @@
       ]
     },
     {
-	  "path": "internal/agentcapabilities/patrol_scope_tools.go",
-	  "rationale": "the typed Patrol resource-scope evidence mapping is both the AI runtime least-manifest projection contract and the canonical API/agent vocabulary that keeps scoped Watch and investigation tool reductions aligned across the Pulse and enterprise boundary",
-	  "subsystems": [
-		"ai-runtime",
-		"api-contracts"
-	  ]
-	},
-	{
+      "path": "internal/agentcapabilities/patrol_scope_tools.go",
+      "rationale": "the typed Patrol resource-scope evidence mapping is both the AI runtime least-manifest projection contract and the canonical API/agent vocabulary that keeps scoped Watch and investigation tool reductions aligned across the Pulse and enterprise boundary",
+      "subsystems": [
+        "ai-runtime",
+        "api-contracts"
+      ]
+    },
+    {
       "path": "internal/agentcapabilities/projection.go",
       "rationale": "the agent capability external-tool projection helper, normalized manifest-owned surface tool contract resolution and tools-affordance gating, manifest-owned resource-context route and argument vocabulary, operator-state capability and route vocabulary, finding workflow capability and lifecycle argument vocabulary including resolution and dismissal notes, governed action capability, route, and argument vocabulary, manifest-owned tool title and outputSchema projection, structured Pulse capability _meta, and shared tool behavior hints are both the canonical API manifest projection contract and the AI runtime adapter projection for Pulse Assistant and MCP-facing agent tools, with MCP annotation and metadata wire names confined to adapter-edge aliases",
       "subsystems": [
@@ -1466,8 +1466,8 @@
               "internal/hostagent/action_runner_client_test.go"
             ]
           },
-        {
-          "id": "agent-privilege-helper-runtime",
+          {
+            "id": "agent-privilege-helper-runtime",
             "label": "typed no-network agent privilege helper proof",
             "match_prefixes": [
               "internal/agenthelper/"
@@ -1479,11 +1479,11 @@
             "test_prefixes": [
               "internal/agenthelper/"
             ],
-          "exact_files": [
-            "cmd/pulse-agent-helper/main_test.go",
-            "internal/agenthelper/container_inventory_test.go",
-            "internal/agenthelper/update_activation_test.go"
-          ]
+            "exact_files": [
+              "cmd/pulse-agent-helper/main_test.go",
+              "internal/agenthelper/container_inventory_test.go",
+              "internal/agenthelper/update_activation_test.go"
+            ]
           },
           {
             "id": "native-pve-action-qualification",
@@ -1746,9 +1746,9 @@
               "internal/hostagent/docker_lifecycle_test.go",
               "internal/hostagent/issue1595_sas_collection_test.go",
               "internal/hostagent/observer_delivery_test.go",
-            "internal/hostagent/package_updates_test.go",
-            "internal/hostagent/privilege_helper_client_test.go",
-            "internal/hostagent/send_report_test.go",
+              "internal/hostagent/package_updates_test.go",
+              "internal/hostagent/privilege_helper_client_test.go",
+              "internal/hostagent/send_report_test.go",
               "internal/hostagent/smartctl_standby_guard_test.go",
               "internal/hostagent/storage_cleanup_test.go",
               "internal/hostagent/unraid_test.go",
@@ -1764,11 +1764,11 @@
             ],
             "allow_same_subsystem_tests": false,
             "test_prefixes": [],
-          "exact_files": [
-            "scripts/installtests/agent_state_dir_lifecycle_test.go",
-            "scripts/installtests/install_sh_test.go",
-            "scripts/installtests/safe_profile_migration_test.go"
-          ]
+            "exact_files": [
+              "scripts/installtests/agent_state_dir_lifecycle_test.go",
+              "scripts/installtests/install_sh_test.go",
+              "scripts/installtests/safe_profile_migration_test.go"
+            ]
           },
           {
             "id": "windows-agent-installer-runtime",
@@ -3251,11 +3251,11 @@
             "test_prefixes": [
               "frontend-modern/src/api/__tests__/"
             ],
-          "exact_files": [
-            "frontend-modern/src/types/api.ts",
-            "internal/api/action_runner_credentials_test.go",
-            "internal/api/ai_handlers_investigation_additional_test.go",
-            "internal/api/ai_handlers_more_test.go",
+            "exact_files": [
+              "frontend-modern/src/types/api.ts",
+              "internal/api/action_runner_credentials_test.go",
+              "internal/api/ai_handlers_investigation_additional_test.go",
+              "internal/api/ai_handlers_more_test.go",
               "internal/api/ai_handlers_patrol_actions_additional_test.go",
               "internal/api/alerting/external_probe_notifications_test.go",
               "internal/api/audit_handlers_test.go",
@@ -4835,14 +4835,14 @@
             ],
             "allow_same_subsystem_tests": false,
             "test_prefixes": [],
-          "exact_files": [
-            "pulse-enterprise:scripts/validate-pro-release-line_test.sh",
-            "scripts/installtests/backfill_release_assets_test.go",
-            "scripts/installtests/build_release_assets_test.go",
-            "scripts/installtests/release_ldflags_test.go",
-            "scripts/installtests/safe_profile_migration_test.go",
-            "scripts/release_control/secure_runtime_attestation_v6_test.py",
-            "scripts/release_control/secure_runtime_attestation_v7_test.py"
+            "exact_files": [
+              "pulse-enterprise:scripts/validate-pro-release-line_test.sh",
+              "scripts/installtests/backfill_release_assets_test.go",
+              "scripts/installtests/build_release_assets_test.go",
+              "scripts/installtests/release_ldflags_test.go",
+              "scripts/installtests/safe_profile_migration_test.go",
+              "scripts/release_control/secure_runtime_attestation_v6_test.py",
+              "scripts/release_control/secure_runtime_attestation_v7_test.py"
             ]
           },
           {
@@ -5088,8 +5088,8 @@
               "tests/integration/tests/16-dev-runtime-recovery.spec.ts"
             ]
           },
-        {
-          "id": "shell-installer-runtime",
+          {
+            "id": "shell-installer-runtime",
             "label": "shell installer runtime proof",
             "match_prefixes": [],
             "match_files": [
@@ -5097,11 +5097,11 @@
             ],
             "allow_same_subsystem_tests": false,
             "test_prefixes": [],
-          "exact_files": [
-            "scripts/installtests/agent_state_dir_lifecycle_test.go",
-            "scripts/installtests/install_sh_test.go",
-            "scripts/installtests/safe_profile_migration_test.go"
-          ]
+            "exact_files": [
+              "scripts/installtests/agent_state_dir_lifecycle_test.go",
+              "scripts/installtests/install_sh_test.go",
+              "scripts/installtests/safe_profile_migration_test.go"
+            ]
           }
         ],
         "match_files": null
@@ -5249,6 +5249,19 @@
         ],
         "require_explicit_path_policy_coverage": true,
         "path_policies": [
+          {
+            "id": "settings-update-feedback",
+            "label": "settings update feedback proof",
+            "match_prefixes": [],
+            "match_files": [
+              "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx"
+            ],
+            "allow_same_subsystem_tests": false,
+            "test_prefixes": [],
+            "exact_files": [
+              "frontend-modern/src/utils/__tests__/updatesPresentation.test.ts"
+            ]
+          },
           {
             "id": "type-to-search-keyboard-ownership",
             "label": "shared search keyboard and modal ownership proof",
@@ -5402,7 +5415,6 @@
               "frontend-modern/src/components/Settings/SSOProvidersPanel.tsx",
               "frontend-modern/src/components/Settings/UpdateInstallGuide.tsx",
               "frontend-modern/src/components/Settings/updatesSettingsModel.ts",
-              "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx",
               "frontend-modern/src/components/Settings/useAISettingsState.ts",
               "frontend-modern/src/components/Settings/useAuditLogPanelState.ts",
               "frontend-modern/src/components/Settings/useAuditWebhookPanelState.ts",
@@ -5509,21 +5521,21 @@
               "frontend-modern/src/utils/__tests__/reportingResourceTypes.test.ts"
             ]
           },
-      {
-        "id": "compact-info-card-consumers",
-        "label": "compact information card consumer proof",
-        "match_prefixes": [],
-        "match_files": [
-          "frontend-modern/src/components/Workloads/AvailabilityProbeSuggestionCard.tsx"
-        ],
-        "allow_same_subsystem_tests": false,
-        "test_prefixes": [],
-        "exact_files": [
-          "frontend-modern/src/components/shared/SharedPrimitives.guardrails.test.ts"
-        ]
-      },
-      {
-        "id": "workload-presentation-helpers",
+          {
+            "id": "compact-info-card-consumers",
+            "label": "compact information card consumer proof",
+            "match_prefixes": [],
+            "match_files": [
+              "frontend-modern/src/components/Workloads/AvailabilityProbeSuggestionCard.tsx"
+            ],
+            "allow_same_subsystem_tests": false,
+            "test_prefixes": [],
+            "exact_files": [
+              "frontend-modern/src/components/shared/SharedPrimitives.guardrails.test.ts"
+            ]
+          },
+          {
+            "id": "workload-presentation-helpers",
             "label": "workload presentation helper proof",
             "match_prefixes": [],
             "match_files": [
@@ -6563,11 +6575,11 @@
         "frontend-modern/src/components/Settings/useRBACFeatureGateState.ts",
         "frontend-modern/src/components/Settings/useRolesPanelState.ts",
         "frontend-modern/src/components/Settings/useUserAssignmentsPanelState.ts",
-		"frontend-modern/src/types/rbac.ts",
+        "frontend-modern/src/types/rbac.ts",
         "frontend-modern/src/utils/organizationRolePresentation.ts",
         "frontend-modern/src/utils/organizationSettingsPresentation.ts",
         "frontend-modern/src/utils/orgUtils.ts",
-		"frontend-modern/src/utils/rbacPresentation.ts",
+        "frontend-modern/src/utils/rbacPresentation.ts",
         "internal/api/access_control_handlers.go",
         "internal/api/enterprise_extension_rbac_admin.go",
         "internal/api/org_handlers.go",
@@ -6592,8 +6604,8 @@
             "match_prefixes": [],
             "match_files": [
               "frontend-modern/src/api/orgs.ts",
-			  "frontend-modern/src/api/rbac.ts",
-			  "frontend-modern/src/types/rbac.ts"
+              "frontend-modern/src/api/rbac.ts",
+              "frontend-modern/src/types/rbac.ts"
             ],
             "allow_same_subsystem_tests": false,
             "test_prefixes": [],
@@ -6682,8 +6694,8 @@
               "frontend-modern/src/components/Settings/useUserAssignmentsPanelState.ts",
               "frontend-modern/src/utils/organizationRolePresentation.ts",
               "frontend-modern/src/utils/organizationSettingsPresentation.ts",
-			  "frontend-modern/src/utils/orgUtils.ts",
-			  "frontend-modern/src/utils/rbacPresentation.ts"
+              "frontend-modern/src/utils/orgUtils.ts",
+              "frontend-modern/src/utils/rbacPresentation.ts"
             ],
             "allow_same_subsystem_tests": false,
             "test_prefixes": [],
@@ -6697,8 +6709,8 @@
               "frontend-modern/src/utils/__tests__/frontendResourceTypeBoundaries.test.ts",
               "frontend-modern/src/utils/__tests__/organizationRolePresentation.test.ts",
               "frontend-modern/src/utils/__tests__/organizationSettingsPresentation.test.ts",
-			  "frontend-modern/src/utils/__tests__/orgUtils.test.ts",
-			  "frontend-modern/src/utils/__tests__/rbacPresentation.test.ts"
+              "frontend-modern/src/utils/__tests__/orgUtils.test.ts",
+              "frontend-modern/src/utils/__tests__/rbacPresentation.test.ts"
             ]
           },
           {
@@ -7489,7 +7501,7 @@
         "pkg/audit/sqlite_logger.go",
         "pkg/auth/agent_credentials.go",
         "pkg/auth/rbac.go",
-		"pkg/auth/rbac_manager.go",
+        "pkg/auth/rbac_manager.go",
         "pkg/auth/sqlite_manager.go",
         "pkg/extensions/audit_admin.go",
         "pkg/server/server.go",
@@ -7527,13 +7539,25 @@
         "require_explicit_path_policy_coverage": true,
         "path_policies": [
           {
+            "id": "system-settings-state",
+            "label": "system settings state proof",
+            "match_prefixes": [],
+            "match_files": [
+              "frontend-modern/src/components/Settings/useSystemSettingsState.ts"
+            ],
+            "allow_same_subsystem_tests": false,
+            "test_prefixes": [],
+            "exact_files": [
+              "frontend-modern/src/components/Settings/__tests__/useSystemSettingsState.test.ts"
+            ]
+          },
+          {
             "id": "privacy-docs-and-telemetry",
             "label": "privacy docs and telemetry proof",
             "match_prefixes": [],
             "match_files": [
               "docs/PRIVACY.md",
               "frontend-modern/public/docs/PRIVACY.md",
-              "frontend-modern/src/components/Settings/useSystemSettingsState.ts",
               "internal/telemetry/service_health.go",
               "internal/telemetry/telemetry.go",
               "pkg/server/server.go",
@@ -7760,7 +7784,7 @@
             "match_prefixes": [],
             "match_files": [
               "pkg/auth/rbac.go",
-			  "pkg/auth/rbac_manager.go",
+              "pkg/auth/rbac_manager.go",
               "pkg/auth/sqlite_manager.go",
               "pkg/server/server.go"
             ],
@@ -7771,7 +7795,7 @@
               "internal/api/rbac_tenant_provider_test.go",
               "internal/api/security_regression_test.go",
               "pkg/auth/rbac_manager_test.go",
-			  "pkg/auth/sqlite_manager_queryplan_test.go",
+              "pkg/auth/sqlite_manager_queryplan_test.go",
               "pkg/auth/sqlite_manager_test.go",
               "pkg/server/server_test.go"
             ]

--- a/docs/release-control/v6/internal/subsystems/security-privacy.md
+++ b/docs/release-control/v6/internal/subsystems/security-privacy.md
@@ -942,6 +942,18 @@ tokens, and path-normalization variants.
 
 ## Current State
 
+### Manual update availability feedback
+
+The settings state owner has a dedicated proof route to
+`useSystemSettingsState.test.ts`, which exercises its telemetry and update
+feedback behavior rather than substituting an unrelated telemetry test.
+
+The system settings owner reads runtime identity from the shared update store,
+rather than retaining a stale snapshot if another check is already pending.
+Manual check failure reports an error and cannot emit a latest-version success
+notification. This read-only feedback does not broaden update installation or
+settings-write permissions.
+
 ### Alert-quality telemetry remains aggregate and comparison-safe
 
 Telemetry schema v14 exports only counts and closed buckets. It exports no

--- a/docs/release-control/v6/internal/subsystems/storage-recovery.md
+++ b/docs/release-control/v6/internal/subsystems/storage-recovery.md
@@ -2597,6 +2597,14 @@ vdev layout is reported` in
 
 ## Current State
 
+### Manual update freshness
+
+Server update-check freshness changes observation only. A refreshed availability
+result or an omitted publication date does not create a backup, perform rollback
+or establish recovery success. Existing update history and recovery authority
+remain independent of GET /api/updates/check.
+
+
 ### TrueNAS workflows hydrate only their owning inventory
 
 The TrueNAS Protection tab is a first-class workflow once a TrueNAS system is

--- a/frontend-modern/browser-verification.json
+++ b/frontend-modern/browser-verification.json
@@ -1,20 +1,32 @@
 {
   "version": 1,
-  "base_sha": "86f99bf9e724699551866e36990ac40224585a28",
-  "verified_at": "2026-09-10T05:44:37.361985Z",
+  "base_sha": "93a039fb17035734bf933caf6be12fe8f849a734",
+  "verified_at": "2026-09-10T14:28:32.143948Z",
   "result": "passed",
   "changed_paths": [
-    "frontend-modern/src/features/alerts/useAlertHistoryState.ts"
+    "frontend-modern/src/api/updates.ts",
+    "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx",
+    "frontend-modern/src/components/Settings/useSystemSettingsState.ts",
+    "frontend-modern/src/stores/updates.ts",
+    "frontend-modern/src/utils/updatesPresentation.ts"
   ],
   "content_sha256": {
-    "frontend-modern/src/features/alerts/useAlertHistoryState.ts": "68bee9367a986329cc63354e781e09137577391671cf0285da0bd74e8df38386"
+    "frontend-modern/src/api/updates.ts": "02539e8292615d218740f2ff157dfe5e1d157a93536216f4dd63b6243e73ac14",
+    "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx": "24fedb95e9f2600a9552d0c731917b62efd376d959cb04dcc7f28e13885f6243",
+    "frontend-modern/src/components/Settings/useSystemSettingsState.ts": "bd481aec6551d0ad93b56aa551b1ca06fbb5f140a715692641d2ec19506e06d3",
+    "frontend-modern/src/stores/updates.ts": "eeb9b3744e43bdf818f6b89eb71ea5380ec33036253c57444f546f5a3a084a17",
+    "frontend-modern/src/utils/updatesPresentation.ts": "d2d8f92b5773d38c86a4808b4d8632381091bb1730fd69a10d8415bc23f3b1ca"
   },
   "routes": [
-    "/history-qualification"
+    "/settings/system-updates"
   ],
   "viewports": [
     {
       "width": 1440,
+      "height": 900
+    },
+    {
+      "width": 900,
       "height": 900
     },
     {
@@ -23,11 +35,18 @@
     }
   ],
   "states": [
-    "Real history hook and administration card with scripted API; existing history and pending range read"
+    "Initial no-update result and live runtime identity",
+    "Pending manual refresh disabled",
+    "Fresh available beta2 with missing, legacy zero and known dates",
+    "Failed refresh retains result and unchanged saved check time, visible inline error",
+    "Successful retry and persisted reload without a release date"
   ],
   "interactions": [
-    "Load row, refresh range, confirm Clear All History, release obsolete response; assert zero rows and settled loading at both widths"
+    "Hover, focus and keyboard Enter on Check Now",
+    "Verified force=true on each manual check without channel override",
+    "Repeat check and provider failure followed by retry",
+    "Reload cached result and inspect pixels at all three widths"
   ],
-  "command": "pulse-heavy-run -- node scripts/check-incident-request-ownership.mjs",
-  "notes": "18 Chromium cases pass including two history clear cases. Narrow screenshot inspected. Component fixture proof, not installed backend deletion or delivery acceptance. First attempt lacked root Playwright dependency; locked npm ci resolved it. Subsequent selector timeout corrected to actual Clear All History label; adverse log retained in lane proof directory."
+  "command": "node .agent-coordination/receipts/release-measurement-resolution-20260910/check-update-freshness.cjs (workspace root)",
+  "notes": "Current local Vite route with real settings/store/API client and controlled update/version HTTP responses. Final4 browser log and screenshots retained locally. Backend cache/JSON separately verified by targeted Go tests. No installation or production runtime change. Browser fixtures do not establish deployed customer behavior."
 }

--- a/frontend-modern/src/api/__tests__/updates.test.ts
+++ b/frontend-modern/src/api/__tests__/updates.test.ts
@@ -52,6 +52,11 @@ describe('UpdatesAPI', () => {
     expect(apiFetchJSONMock).toHaveBeenCalledWith('/api/updates/check?channel=rc');
   });
 
+  it('passes explicit freshness without overriding the saved channel', async () => {
+    await UpdatesAPI.checkForUpdates(undefined, true);
+    expect(apiFetchJSONMock).toHaveBeenCalledWith('/api/updates/check?force=true');
+  });
+
   it('omits blank channel for update checks', async () => {
     apiFetchJSONMock.mockResolvedValueOnce({ available: false } as any);
     await UpdatesAPI.checkForUpdates('   ' as UpdateChannel);

--- a/frontend-modern/src/api/updates.ts
+++ b/frontend-modern/src/api/updates.ts
@@ -6,7 +6,7 @@ export interface UpdateInfo {
   currentVersion: string;
   latestVersion: string;
   releaseNotes: string;
-  releaseDate: string;
+  releaseDate?: string;
   downloadUrl: string;
   isPrerelease: boolean;
   isMajorUpgrade: boolean;
@@ -116,12 +116,13 @@ const requireNonEmpty = (value: string, fieldName: string): string => {
 };
 
 export class UpdatesAPI {
-  static async checkForUpdates(channel?: UpdateChannel): Promise<UpdateInfo> {
+  static async checkForUpdates(channel?: UpdateChannel, force = false): Promise<UpdateInfo> {
     const search = new URLSearchParams();
     const trimmedChannel = channel?.trim();
     if (trimmedChannel) {
       search.set('channel', trimmedChannel);
     }
+    if (force) search.set('force', 'true');
     const query = search.toString();
     const url = query ? `/api/updates/check?${query}` : '/api/updates/check';
     return apiFetchJSON(url);

--- a/frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx
+++ b/frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx
@@ -27,6 +27,7 @@ import {
 } from '@/components/Settings/updatesSettingsModel';
 import {
   getUpdateCheckActionLabel,
+  formatUpdateReleaseDate,
   getUpdateAvailabilityHeading,
   getUpdateBuildBadges,
   getUpdateCheckedLabel,
@@ -204,9 +205,9 @@ export const UpdatesSettingsPanel: Component<UpdatesSettingsPanelProps> = (props
                       <p class="mt-1 text-lg font-bold text-green-700 dark:text-green-300">
                         {props.updateInfo()?.latestVersion}
                       </p>
-                      <Show when={props.updateInfo()?.releaseDate}>
+                      <Show when={formatUpdateReleaseDate(props.updateInfo()?.releaseDate)}>
                         <p class="mt-0.5 text-xs text-green-600 dark:text-green-400">
-                          Released {new Date(props.updateInfo()!.releaseDate).toLocaleDateString()}
+                          Released {formatUpdateReleaseDate(props.updateInfo()?.releaseDate)}
                         </p>
                       </Show>
                     </Show>
@@ -214,6 +215,13 @@ export const UpdatesSettingsPanel: Component<UpdatesSettingsPanelProps> = (props
                 </div>
               </div>
             </div>
+
+            <Show when={updateStore.lastError()}>
+              <p role="alert" class="px-4 py-3 text-sm text-red-600 dark:text-red-400">
+                Could not check for updates.
+                <Show when={props.updateInfo()}> Showing the last successful result.</Show>
+              </p>
+            </Show>
 
             {/* Check for updates button */}
             <div class="bg-surface border-t border-border px-4 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">

--- a/frontend-modern/src/components/Settings/__tests__/useSystemSettingsState.branchcov0722pm.test.ts
+++ b/frontend-modern/src/components/Settings/__tests__/useSystemSettingsState.branchcov0722pm.test.ts
@@ -78,6 +78,7 @@ vi.mock('@/utils/apiClient', () => ({
 
 vi.mock('@/stores/updates', () => ({
   updateStore: {
+    lastError: vi.fn().mockReturnValue(null),
     checkForUpdates: mocks.updateStoreCheckForUpdatesMock,
     applyUpdate: mocks.updateStoreApplyUpdateMock,
     updateInfo: mocks.updateStoreUpdateInfoMock,

--- a/frontend-modern/src/components/Settings/__tests__/useSystemSettingsState.test.ts
+++ b/frontend-modern/src/components/Settings/__tests__/useSystemSettingsState.test.ts
@@ -308,6 +308,7 @@ describe('useSystemSettingsState', () => {
 
     vi.doMock('@/stores/updates', () => ({
       updateStore: {
+        lastError: vi.fn().mockReturnValue(null),
         checkForUpdates: vi.fn().mockResolvedValue(undefined),
         applyUpdate: vi.fn().mockResolvedValue(true),
         updateInfo: vi.fn().mockReturnValue(null),
@@ -367,6 +368,19 @@ describe('useSystemSettingsState', () => {
 
     return { dispose, hookState: hookState! };
   };
+
+  it('does not report latest-version success when a manual refresh fails', async () => {
+    const { hookState, dispose } = mountHookWithTab('system-updates');
+    const { updateStore } = await import('@/stores/updates');
+    const { notificationStore } = await import('@/stores/notifications');
+    vi.mocked(updateStore.lastError).mockReturnValue('Refresh unavailable');
+    await hookState.checkForUpdates();
+    expect(hookState.checkingForUpdates()).toBe(false);
+    expect(notificationStore.success).not.toHaveBeenCalledWith(
+      'You are running the latest version',
+    );
+    dispose();
+  });
 
   it('shows clean success toast without port reference when saving from General tab', async () => {
     const { hookState, dispose } = mountHookWithTab('system-general');

--- a/frontend-modern/src/components/Settings/useSystemSettingsState.ts
+++ b/frontend-modern/src/components/Settings/useSystemSettingsState.ts
@@ -1,7 +1,7 @@
 import { Accessor, Setter, createSignal } from 'solid-js';
 import { SettingsAPI, type TelemetryPreviewResponse } from '@/api/settings';
 import { UpdatesAPI } from '@/api/updates';
-import type { UpdateInfo, UpdatePlan, VersionInfo } from '@/api/updates';
+import type { UpdateInfo, UpdatePlan } from '@/api/updates';
 import { notificationStore } from '@/stores/notifications';
 import { logger } from '@/utils/logger';
 import { updateStore } from '@/stores/updates';
@@ -73,7 +73,7 @@ export function useSystemSettingsState({
   );
   const [loadingTelemetryPreview, setLoadingTelemetryPreview] = createSignal(false);
   const [resettingTelemetryInstallID, setResettingTelemetryInstallID] = createSignal(false);
-  const [versionInfo, setVersionInfo] = createSignal<VersionInfo | null>(null);
+  const versionInfo = updateStore.versionInfo;
   const [updateInfo, setUpdateInfo] = createSignal<UpdateInfo | null>(null);
   const [checkingForUpdates, setCheckingForUpdates] = createSignal(false);
   const [updateChannel, setUpdateChannel] = createSignal<'stable' | 'rc'>('stable');
@@ -218,17 +218,7 @@ export function useSystemSettingsState({
     }
 
     try {
-      const cachedVersion = updateStore.versionInfo();
-      if (cachedVersion) {
-        setVersionInfo(cachedVersion);
-      }
-
       await updateStore.checkForUpdates();
-      const version = updateStore.versionInfo();
-      if (version) {
-        setVersionInfo(version);
-      }
-
       const storeInfo = updateStore.updateInfo();
       if (storeInfo) {
         setUpdateInfo(storeInfo);
@@ -242,6 +232,7 @@ export function useSystemSettingsState({
         }
       }
 
+      const version = versionInfo();
       if (version?.channel && !updateChannel()) {
         setUpdateChannel(version.channel as 'stable' | 'rc');
       }
@@ -499,6 +490,7 @@ export function useSystemSettingsState({
     setCheckingForUpdates(true);
     try {
       await updateStore.checkForUpdates(true);
+      if (updateStore.lastError()) return;
       const info = updateStore.updateInfo();
       setUpdateInfo(info);
 

--- a/frontend-modern/src/stores/__tests__/updates.test.ts
+++ b/frontend-modern/src/stores/__tests__/updates.test.ts
@@ -62,6 +62,39 @@ describe('updateStore', () => {
     mockNotifyError.mockReset();
   });
 
+  it('forces a server refresh and preserves an unknown date in cached results', async () => {
+    mockGetVersion.mockResolvedValue(baseVersionInfo);
+    const info = { ...baseUpdateInfo, releaseDate: undefined };
+    mockCheckForUpdates.mockResolvedValue(info);
+    const store = await loadUpdateStore();
+    await store.checkForUpdates(true);
+    expect(mockCheckForUpdates).toHaveBeenCalledWith(undefined, true);
+    await store.checkForUpdates();
+    expect(mockCheckForUpdates).toHaveBeenCalledTimes(1);
+    expect(store.updateInfo()?.latestVersion).toBe(info.latestVersion);
+  });
+
+  it('does not drop a manual refresh arriving during a background check', async () => {
+    mockGetVersion.mockResolvedValue(baseVersionInfo);
+    let finish: (value: typeof baseUpdateInfo) => void = () => {};
+    mockCheckForUpdates.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    mockCheckForUpdates.mockResolvedValueOnce({ ...baseUpdateInfo, latestVersion: 'v1.2.0' });
+    const store = await loadUpdateStore();
+    const background = store.checkForUpdates();
+    await vi.waitFor(() => expect(mockCheckForUpdates).toHaveBeenCalledTimes(1));
+    const manual = store.checkForUpdates(true);
+    finish(baseUpdateInfo);
+    await Promise.all([background, manual]);
+    expect(mockCheckForUpdates).toHaveBeenNthCalledWith(1, undefined, false);
+    expect(mockCheckForUpdates).toHaveBeenNthCalledWith(2, undefined, true);
+    expect(store.updateInfo()?.latestVersion).toBe('v1.2.0');
+  });
+
   it('retries transient update-check failures before succeeding', async () => {
     mockGetVersion.mockResolvedValue(baseVersionInfo);
     mockCheckForUpdates

--- a/frontend-modern/src/stores/updates.ts
+++ b/frontend-modern/src/stores/updates.ts
@@ -55,7 +55,7 @@ const normalizeUpdateInfo = (value: unknown): UpdateInfo | undefined => {
     typeof currentVersion !== 'string' ||
     typeof latestVersion !== 'string' ||
     typeof releaseNotes !== 'string' ||
-    typeof releaseDate !== 'string' ||
+    (releaseDate !== undefined && typeof releaseDate !== 'string') ||
     typeof downloadUrl !== 'string' ||
     typeof isPrerelease !== 'boolean'
   ) {
@@ -298,10 +298,24 @@ const rollbackUpdate = async (params: {
 };
 
 // Check for updates
-const checkForUpdates = async (force = false): Promise<void> => {
-  // Don't check if already checking
-  if (isChecking()) return;
+let checkInFlight: Promise<void> | undefined;
 
+const checkForUpdates = async (force = false): Promise<void> => {
+  // A manual check arriving during a background check must still request fresh data.
+  while (checkInFlight) {
+    await checkInFlight;
+    if (!force) return;
+  }
+  const pending = performUpdateCheck(force);
+  checkInFlight = pending;
+  try {
+    await pending;
+  } finally {
+    if (checkInFlight === pending) checkInFlight = undefined;
+  }
+};
+
+const performUpdateCheck = async (force: boolean): Promise<void> => {
   const state = loadState();
   const now = Date.now();
 
@@ -381,7 +395,9 @@ const checkForUpdates = async (force = false): Promise<void> => {
     }
 
     // Get the saved update channel from system settings
-    const info = await withTransientRetry('check request', () => UpdatesAPI.checkForUpdates());
+    const info = await withTransientRetry('check request', () =>
+      UpdatesAPI.checkForUpdates(undefined, force),
+    );
 
     setUpdateInfo(info);
     setUpdateAvailable(info.available);
@@ -394,10 +410,11 @@ const checkForUpdates = async (force = false): Promise<void> => {
     }
 
     // Save to cache
-    setLastCheckedAt(now);
+    const completedAt = Date.now();
+    setLastCheckedAt(completedAt);
     saveState({
       ...state,
-      lastCheck: now,
+      lastCheck: completedAt,
       updateInfo: info,
     });
   } catch (error) {

--- a/frontend-modern/src/utils/__tests__/updatesPresentation.test.ts
+++ b/frontend-modern/src/utils/__tests__/updatesPresentation.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   getUpdateCheckActionLabel,
+  formatUpdateReleaseDate,
   getUpdateAvailabilityHeading,
   getUpdateBuildBadges,
   getUpdateCheckedLabel,
@@ -76,4 +77,12 @@ describe('updatesPresentation', () => {
       );
     });
   });
+});
+
+it('omits unknown and invalid release dates while formatting known dates', () => {
+  for (const value of [undefined, '', '0001-01-01T00:00:00Z', 'invalid']) {
+    expect(formatUpdateReleaseDate(value)).toBeUndefined();
+  }
+  const date = '2026-09-10T14:06:01Z';
+  expect(formatUpdateReleaseDate(date)).toBe(new Date(date).toLocaleDateString());
 });

--- a/frontend-modern/src/utils/updatesPresentation.ts
+++ b/frontend-modern/src/utils/updatesPresentation.ts
@@ -86,3 +86,10 @@ export function getUpdateCheckedLabel(lastCheckedMs: number | null | undefined):
 export function getUpdateCheckActionLabel(checking: boolean): string {
   return checking ? UPDATES_PANEL_COPY.checkingLabel : UPDATES_PANEL_COPY.checkNowLabel;
 }
+
+// Older servers serialize an unknown release date as Go's zero time.
+export function formatUpdateReleaseDate(value?: string): string | undefined {
+  if (!value || value.startsWith('0001-01-01')) return undefined;
+  const date = new Date(value);
+  return Number.isFinite(date.getTime()) ? date.toLocaleDateString() : undefined;
+}

--- a/internal/api/updates.go
+++ b/internal/api/updates.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -36,7 +37,7 @@ type UpdateHandlers struct {
 
 // UpdateManager defines the interface for update management operations
 type UpdateManager interface {
-	CheckForUpdatesWithChannel(ctx context.Context, channel string) (*updates.UpdateInfo, error)
+	CheckForUpdatesWithOptions(ctx context.Context, options updates.UpdateCheckOptions) (*updates.UpdateInfo, error)
 	ApplyUpdate(ctx context.Context, req updates.ApplyUpdateRequest) error
 	RollbackToBackup(ctx context.Context, req updates.RollbackRequest) error
 	GetStatus() updates.UpdateStatus
@@ -112,7 +113,20 @@ func (h *UpdateHandlers) HandleCheckUpdates(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	info, err := h.manager.CheckForUpdatesWithChannel(ctx, channel)
+	force := false
+	if raw, present := r.URL.Query()["force"]; present {
+		if len(raw) != 1 {
+			http.Error(w, "force must be a boolean", http.StatusBadRequest)
+			return
+		}
+		force, err = strconv.ParseBool(raw[0])
+		if err != nil {
+			http.Error(w, "force must be a boolean", http.StatusBadRequest)
+			return
+		}
+	}
+	w.Header().Set("Cache-Control", "no-store")
+	info, err := h.manager.CheckForUpdatesWithOptions(ctx, updates.UpdateCheckOptions{Channel: channel, Force: force})
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to check for updates")
 		http.Error(w, "Failed to check for updates", http.StatusInternalServerError)

--- a/internal/api/updates_test.go
+++ b/internal/api/updates_test.go
@@ -17,6 +17,7 @@ import (
 
 // MockUpdateManager implements UpdateManager interface for testing
 type MockUpdateManager struct {
+	CheckOptionsFunc       func(context.Context, updates.UpdateCheckOptions) (*updates.UpdateInfo, error)
 	CheckForUpdatesFunc    func(ctx context.Context, channel string) (*updates.UpdateInfo, error)
 	GetReleaseNotesFunc    func(ctx context.Context, version string) (*updates.ReleaseNotesInfo, error)
 	ApplyUpdateFunc        func(ctx context.Context, req updates.ApplyUpdateRequest) error
@@ -34,7 +35,11 @@ func (m *MockUpdateManager) GetReleaseNotes(ctx context.Context, version string)
 	return nil, updates.ErrReleaseNotFound
 }
 
-func (m *MockUpdateManager) CheckForUpdatesWithChannel(ctx context.Context, channel string) (*updates.UpdateInfo, error) {
+func (m *MockUpdateManager) CheckForUpdatesWithOptions(ctx context.Context, options updates.UpdateCheckOptions) (*updates.UpdateInfo, error) {
+	if m.CheckOptionsFunc != nil {
+		return m.CheckOptionsFunc(ctx, options)
+	}
+	channel := options.Channel
 	if m.CheckForUpdatesFunc != nil {
 		return m.CheckForUpdatesFunc(ctx, channel)
 	}
@@ -1038,5 +1043,37 @@ func TestClassifyApplyUpdateStartError_ProActivation(t *testing.T) {
 	}
 	if !strings.Contains(msg, "activated license") {
 		t.Fatalf("expected the actionable refusal message to pass through, got %q", msg)
+	}
+}
+
+func TestHandleCheckUpdatesFreshness(t *testing.T) {
+	for _, tc := range []struct {
+		query  string
+		status int
+		force  bool
+	}{
+		{"", 200, false}, {"?force=true", 200, true}, {"?channel=rc&force=true", 200, true}, {"?force=false", 200, false}, {"?force=maybe", 400, false}, {"?force=true&force=false", 400, false},
+	} {
+		t.Run(tc.query, func(t *testing.T) {
+			called := false
+			m := &MockUpdateManager{CheckOptionsFunc: func(_ context.Context, options updates.UpdateCheckOptions) (*updates.UpdateInfo, error) {
+				called = true
+				if options.Force != tc.force {
+					t.Fatalf("force=%v", options.Force)
+				}
+				if strings.Contains(tc.query, "channel=rc") && options.Channel != "rc" {
+					t.Fatalf("channel=%q", options.Channel)
+				}
+				return &updates.UpdateInfo{}, nil
+			}}
+			w := httptest.NewRecorder()
+			NewUpdateHandlers(m, nil).HandleCheckUpdates(w, httptest.NewRequest("GET", "/updates/check"+tc.query, nil))
+			if w.Code != tc.status || called != (tc.status == 200) {
+				t.Fatalf("status=%d called=%v", w.Code, called)
+			}
+			if tc.status == 200 && w.Header().Get("Cache-Control") != "no-store" {
+				t.Fatal("missing no-store")
+			}
+		})
 	}
 }

--- a/internal/updates/manager.go
+++ b/internal/updates/manager.go
@@ -64,7 +64,7 @@ type UpdateInfo struct {
 	CurrentVersion string    `json:"currentVersion"`
 	LatestVersion  string    `json:"latestVersion"`
 	ReleaseNotes   string    `json:"releaseNotes"`
-	ReleaseDate    time.Time `json:"releaseDate"`
+	ReleaseDate    time.Time `json:"releaseDate,omitzero"`
 	DownloadURL    string    `json:"downloadUrl"`
 	IsPrerelease   bool      `json:"isPrerelease"`
 	IsMajorUpgrade bool      `json:"isMajorUpgrade"`
@@ -360,6 +360,18 @@ func (m *Manager) CheckForUpdates(ctx context.Context) (*UpdateInfo, error) {
 
 // CheckForUpdatesWithChannel checks GitHub for available updates with optional channel override
 func (m *Manager) CheckForUpdatesWithChannel(ctx context.Context, channel string) (*UpdateInfo, error) {
+	return m.CheckForUpdatesWithOptions(ctx, UpdateCheckOptions{Channel: channel})
+}
+
+// UpdateCheckOptions controls channel selection and explicit freshness requests.
+type UpdateCheckOptions struct {
+	Channel string
+	Force   bool
+}
+
+// CheckForUpdatesWithOptions refreshes the saved-channel cache after a forced check.
+func (m *Manager) CheckForUpdatesWithOptions(ctx context.Context, options UpdateCheckOptions) (*UpdateInfo, error) {
+	channel := options.Channel
 	// Get current version first to auto-detect channel if needed
 	currentInfo, err := GetCurrentVersion()
 	if err != nil {
@@ -376,7 +388,7 @@ func (m *Manager) CheckForUpdatesWithChannel(ctx context.Context, channel string
 	useCache := !explicitChannelProvided
 
 	// Check cache first (only if using saved channel)
-	if useCache {
+	if useCache && !options.Force {
 		m.statusMu.RLock()
 		cachedInfo, hasCached := m.checkCache[channel]
 		cachedTime, hasTime := m.cacheTime[channel]
@@ -444,6 +456,10 @@ func (m *Manager) CheckForUpdatesWithChannel(ctx context.Context, channel string
 		if errors.Is(err, errGitHubRateLimited) {
 			log.Warn().Err(err).Str("channel", channel).Msg("GitHub rate limit encountered while checking for updates")
 
+			if options.Force {
+				m.updateStatus("error", 0, "Fresh update check unavailable", err)
+				return nil, fmt.Errorf("fresh update check unavailable: %w", err)
+			}
 			if useCache {
 				m.statusMu.RLock()
 				cachedInfo, hasCached := m.checkCache[channel]

--- a/internal/updates/manager_check_updates_test.go
+++ b/internal/updates/manager_check_updates_test.go
@@ -3,9 +3,11 @@ package updates
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -193,5 +195,81 @@ func TestCheckForUpdates_Wrapper(t *testing.T) {
 	}
 	if info.LatestVersion != "99.1.0" {
 		t.Fatalf("LatestVersion = %q, want 99.1.0", info.LatestVersion)
+	}
+}
+
+func TestForcedUpdateCheckRefreshesSavedChannelCache(t *testing.T) {
+	var hits int32
+	server := newReleaseServer(t, []ReleaseInfo{{TagName: "v99.0.0", Assets: []ReleaseAsset{{Name: "pulse-v99.0.0-linux-amd64.tar.gz", BrowserDownloadURL: "https://example.com/new.tar.gz"}}}}, &hits)
+	defer server.Close()
+	t.Setenv("PULSE_UPDATE_SERVER", server.URL)
+	manager := NewManager(&config.Config{UpdateChannel: "stable"})
+	manager.checkCache["stable"] = &UpdateInfo{LatestVersion: "98.0.0"}
+	manager.cacheTime["stable"] = time.Now()
+	cached, err := manager.CheckForUpdates(context.Background())
+	if err != nil || cached.LatestVersion != "98.0.0" || hits != 0 {
+		t.Fatalf("cached check: %+v %v hits=%d", cached, err, hits)
+	}
+	fresh, err := manager.CheckForUpdatesWithOptions(context.Background(), UpdateCheckOptions{Force: true})
+	if err != nil || fresh.LatestVersion != "99.0.0" {
+		t.Fatalf("fresh check: %+v %v", fresh, err)
+	}
+	again, err := manager.CheckForUpdates(context.Background())
+	if err != nil || again.LatestVersion != "99.0.0" || atomic.LoadInt32(&hits) != 1 {
+		t.Fatalf("refreshed cache: %+v %v hits=%d", again, err, hits)
+	}
+}
+
+func TestUpdateInfoReleaseDateOmitsUnknownTime(t *testing.T) {
+	for _, date := range []time.Time{{}, time.Date(2026, 9, 10, 14, 6, 1, 0, time.UTC)} {
+		raw, err := json.Marshal(UpdateInfo{ReleaseDate: date})
+		if err != nil {
+			t.Fatal(err)
+		}
+		var wire map[string]any
+		if err := json.Unmarshal(raw, &wire); err != nil {
+			t.Fatal(err)
+		}
+		value, present := wire["releaseDate"]
+		if present == date.IsZero() {
+			t.Fatalf("unexpected date presence: %s", raw)
+		}
+		if present && value != date.Format(time.RFC3339) {
+			t.Fatalf("date changed: %v", value)
+		}
+	}
+}
+
+func TestForcedUpdateCheckDoesNotReturnCachedResultOnRateLimit(t *testing.T) {
+	setRetrySettingsForTest(t, 1, time.Millisecond, time.Millisecond)
+	withBuildVersion(t, "6.4.0")
+	t.Setenv("PULSE_UPDATE_SERVER", "")
+	original := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		status := http.StatusNotFound
+		body := "not found"
+		header := http.Header{}
+		if req.URL.Host == "api.github.com" {
+			status = http.StatusForbidden
+			body = `{"message":"API rate limit exceeded"}`
+			header.Set("X-RateLimit-Remaining", "0")
+		}
+		return &http.Response{StatusCode: status, Body: io.NopCloser(strings.NewReader(body)), Header: header, Request: req}, nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = original })
+	manager := NewManager(&config.Config{UpdateChannel: "stable"})
+	old := &UpdateInfo{LatestVersion: "6.4.1"}
+	at := time.Now()
+	manager.checkCache["stable"] = old
+	manager.cacheTime["stable"] = at
+	info, err := manager.CheckForUpdatesWithOptions(context.Background(), UpdateCheckOptions{Force: true})
+	if err == nil || info != nil {
+		t.Fatalf("forced failure returned %+v, %v", info, err)
+	}
+	if manager.checkCache["stable"] != old || !manager.cacheTime["stable"].Equal(at) {
+		t.Fatal("failure replaced cache or freshness")
+	}
+	if manager.GetStatus().Status != "error" {
+		t.Fatalf("status=%+v", manager.GetStatus())
 	}
 }

--- a/scripts/release_control/canonical_completion_guard_test.py
+++ b/scripts/release_control/canonical_completion_guard_test.py
@@ -2830,6 +2830,21 @@ None yet.
             ],
         )
 
+    def test_update_settings_use_their_own_behavioral_proofs(self):
+        for subsystem, source, proof, policy in [
+            ("frontend-primitives", "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx",
+             "frontend-modern/src/utils/__tests__/updatesPresentation.test.ts", "settings-update-feedback"),
+            ("security-privacy", "frontend-modern/src/components/Settings/useSystemSettingsState.ts",
+             "frontend-modern/src/components/Settings/__tests__/useSystemSettingsState.test.ts", "system-settings-state"),
+        ]:
+            with self.subTest(subsystem=subsystem):
+                rule = next(rule for rule in load_subsystem_rules() if rule["id"] == subsystem)
+                requirements = build_verification_requirements(rule, [source])
+                self.assertEqual(len(requirements), 1)
+                self.assertEqual(requirements[0]["id"], policy)
+                self.assertEqual(requirements[0]["exact_files"], [proof])
+                self.assertFalse(requirements[0]["allow_same_subsystem_tests"])
+
     def test_frontend_primitive_remaining_settings_shells_use_specific_guardrails(self):
         rule = next(rule for rule in load_subsystem_rules() if rule["id"] == "frontend-primitives")
         runtime_files = [
@@ -2841,7 +2856,6 @@ None yet.
             "frontend-modern/src/components/Settings/RecoverySettingsPanel.tsx",
             "frontend-modern/src/components/Settings/SecurityOverviewPanel.tsx",
             "frontend-modern/src/components/Settings/SSOProvidersPanel.tsx",
-            "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx",
         ]
         requirements = build_verification_requirements(rule, runtime_files)
         self.assertEqual(

--- a/scripts/release_control/subsystem_lookup_test.py
+++ b/scripts/release_control/subsystem_lookup_test.py
@@ -2616,6 +2616,12 @@ class SubsystemLookupTest(unittest.TestCase):
             )
             self.assertEqual(match["contract"], "docs/release-control/v6/internal/subsystems/frontend-primitives.md")
             self.assertEqual(match["lane_context"]["lane_id"], "L8")
+            if file_entry["path"] == "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx":
+                self.assertEqual(match["verification_requirement"]["id"], "settings-update-feedback")
+                self.assertEqual(match["verification_requirement"]["exact_files"], [
+                    "frontend-modern/src/utils/__tests__/updatesPresentation.test.ts"
+                ])
+                continue
             self.assertEqual(
                 match["verification_requirement"]["id"],
                 "settings-shell-and-framing",


### PR DESCRIPTION
Check Now could report a just-published preview as unavailable because it reused the server cache, and failed checks could still show a latest-version success message. Manual checks now request fresh provider data, wait for an ongoing background check before refreshing, and retain the previous result and age when refresh fails. Unknown publication dates are omitted, and runtime identity follows the shared update store.

Validation: targeted Go manager and HTTP handler tests passed, including cache replacement and rate-limit failure. 110 frontend tests, TypeScript and targeted ESLint passed. Chromium exercised `/settings/system-updates` at 1440, 900 and 390 pixels with controlled update responses, covering keyboard refresh, pending state, failure/retry, unknown/zero/known dates and cached reload. This is source verification for a subsequent release, not a deployment to existing installations.
