### PR TITLE
Keep diagnostic source builds out of release update flows

### DIFF
--- a/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
+++ b/docs/release-control/v6/internal/subsystems/agent-lifecycle.md
@@ -1187,7 +1187,11 @@ connection IDs, but command rendering stays lifecycle-owned in Settings.
 `currentAgentTargetVersion()` is the canonical agent update target and must be
 projected to browser clients as `/api/version.agentUpdateTargetVersion`;
 platform pages and Settings must not compare agent binaries against the app
-build `version` when the server would tell agents `dev`. For Unix-like agents
+build `version` when the server would tell agents `dev`. The same exclusion
+applies when `isSourceBuild` is true, including a server
+whose injected version carries diagnostic test metadata. Such a build has no
+published agent target and must not ask existing agents to install its
+unpublished server version. For Unix-like agents
 that Pulse already sees, the copied stale-agent update command must use
 `scripts/install.sh --update` and recover URL, token, identity, custom CA, and
 insecure transport from installer-owned saved state instead of asking the

--- a/docs/release-control/v6/internal/subsystems/api-contracts.md
+++ b/docs/release-control/v6/internal/subsystems/api-contracts.md
@@ -1104,6 +1104,11 @@ builds that intentionally report `dev` to agents do not surface update nags
 when no real agent update target exists. Windows remains on the existing
 token-gated PowerShell payload until its installer owns the same saved-state
 update contract.
+This exclusion also covers build-injected diagnostic metadata and explicit
+source-build markers. `/api/version` preserves the full diagnostic version,
+sets `isSourceBuild`, and omits both `channel` and `agentUpdateTargetVersion`.
+`TestHandleVersionBuildIdentityContract` exercises the actual handler response
+for a release, a diagnostic build, and a marker-declared source build.
 
 Summary-chart response caching is a shared API boundary:
 `internal/api/chartapi/service.go` may serve a short cached JSON payload for repeated

--- a/docs/release-control/v6/internal/subsystems/deployment-installability.md
+++ b/docs/release-control/v6/internal/subsystems/deployment-installability.md
@@ -3295,6 +3295,13 @@ strings into normalized release identity fields for browser preview payloads
 and operator telemetry reporting, so unpublished `git describe` / manual / dev
 builds cannot pollute published stable or RC adoption reads just because they
 share a semver-looking prefix.
+Runtime version responses consume that same identity. Build metadata such as
+`6.4.1+test.1913.bd37ae18`, development bases, and sentinel versions are source
+builds even when their version was injected by release build tooling. Their
+exact version remains visible, but they expose no published release channel
+and do not enter the release-update flow. The existing `BUILD_FROM_SOURCE`
+marker retains the same source-only update restriction. Published stable and
+preview builds retain their normal channel and update behavior.
 The development flag in that identity is defined by the `0.0.0` sentinel, not
 by prerelease spelling. `normalizeVersionString` assigns `0.0.0-<sanitized>` to
 every build string it cannot parse as a release version, so any version whose

--- a/docs/release-control/v6/internal/subsystems/frontend-primitives.md
+++ b/docs/release-control/v6/internal/subsystems/frontend-primitives.md
@@ -5474,6 +5474,16 @@ the global payload boundary is
 `frontend-modern/src/features/alerts/__tests__/useAlertsConfigurationState.test.tsx`.
 
 The updates settings surface now follows the same presentation-owner rule.
+Source builds have no published release-update target. The shared update
+store must discard a cached release offer when the current runtime reports
+`isSourceBuild` or `isDevelopment`, even if its version string did not change.
+The update panel labels this state `Source build`, disables release checks
+and automatic updates, and omits release notes. `UpdateInstallGuide` suppresses
+release install actions and generic Docker pull commands for source builds,
+including stale cached offers. Docker source builds instead explain manual
+image replacement. Stable and preview release flows retain their existing
+checks and installation guidance. The update-store, install-guide, and
+presentation tests own this cross-control contract.
 `frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx` stays the
 top-level settings shell, while
 `frontend-modern/src/components/Settings/UpdateInstallGuide.tsx`,

--- a/docs/release-control/v6/internal/subsystems/registry.json
+++ b/docs/release-control/v6/internal/subsystems/registry.json
@@ -5215,6 +5215,7 @@
         "frontend-modern/src/index.css",
         "frontend-modern/src/routing/routePreload.ts",
         "frontend-modern/src/stores/aiChat.ts",
+        "frontend-modern/src/stores/updates.ts",
         "frontend-modern/src/utils/aiSettingsPresentation.ts",
         "frontend-modern/src/utils/diagnosticsPresentation.ts",
         "frontend-modern/src/utils/discoveryPresentation.ts",
@@ -5249,6 +5250,32 @@
         ],
         "require_explicit_path_policy_coverage": true,
         "path_policies": [
+          {
+            "id": "settings-update-install-guide",
+            "label": "settings update install guide proof",
+            "match_prefixes": [],
+            "match_files": [
+              "frontend-modern/src/components/Settings/UpdateInstallGuide.tsx"
+            ],
+            "allow_same_subsystem_tests": false,
+            "test_prefixes": [],
+            "exact_files": [
+              "frontend-modern/src/components/Settings/__tests__/UpdateInstallGuide.test.tsx"
+            ]
+          },
+          {
+            "id": "release-update-store",
+            "label": "release update store proof",
+            "match_prefixes": [],
+            "match_files": [
+              "frontend-modern/src/stores/updates.ts"
+            ],
+            "allow_same_subsystem_tests": false,
+            "test_prefixes": [],
+            "exact_files": [
+              "frontend-modern/src/stores/__tests__/updates.test.ts"
+            ]
+          },
           {
             "id": "settings-update-feedback",
             "label": "settings update feedback proof",

--- a/docs/release-control/v6/internal/subsystems/storage-recovery.md
+++ b/docs/release-control/v6/internal/subsystems/storage-recovery.md
@@ -397,6 +397,12 @@ protection posture, recovery-point evidence, or restore readiness.
 
 ## Extension Points
 
+Diagnostic source-build identity is not a recovery checkpoint or a schema
+transition. A build-injected test version retains the current data and config
+while the version API disables release-update and agent-target suggestions.
+Returning from a reporter image remains an explicit image rollback with the
+operator's backup available, not an automatic update or retention action.
+
 The authenticated runtime-display projection under shared `internal/api/` may
 publish effective Docker-action visibility and outbound-telemetry booleans,
 plus the effective PVE polling cadence in seconds, to read-only viewers. Those

--- a/frontend-modern/browser-verification.json
+++ b/frontend-modern/browser-verification.json
@@ -1,19 +1,22 @@
 {
   "version": 1,
-  "base_sha": "837a5b8843fa4a4ca293f66f43123b9f9c127d4d",
-  "verified_at": "2026-09-10T14:54:37.800409Z",
+  "base_sha": "dd388decf5896123b6587b1b16f9aee7c3a747f3",
+  "verified_at": "2026-09-10T16:01:12.114821Z",
   "result": "passed",
   "changed_paths": [
-    "internal/monitoring/monitored_system_usage.go",
-    "internal/unifiedresources/monitor_adapter.go",
-    "internal/unifiedresources/registry.go"
+    "frontend-modern/src/components/Settings/UpdateInstallGuide.tsx",
+    "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx",
+    "frontend-modern/src/utils/updatesPresentation.ts",
+    "frontend-modern/src/stores/updates.ts"
   ],
   "content_sha256": {
-    "internal/monitoring/monitored_system_usage.go": "125f39dbfc448a37d0ee74756a03534d435abdacb4e0c7fed8c0710364af5f4a",
-    "internal/unifiedresources/monitor_adapter.go": "7720ba164373cdf6a8a9f950215f27e0e5a24e48edc2f9c1e444b4144e35b3d6",
-    "internal/unifiedresources/registry.go": "b49125258595bfdabb2a0a06dc51e51e7e27f998c8d9cb8e8ad69cffc1e4272c"
+    "frontend-modern/src/components/Settings/UpdateInstallGuide.tsx": "ee102c072050b70fe0fcf732073f6016cc6ac853edbac2d1e1db6c1ec7bda5a6",
+    "frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx": "f4f5f9bb31be48b20fc8a08175c378f071b61a5b20fe05a51c5990290026bf6f",
+    "frontend-modern/src/utils/updatesPresentation.ts": "c279a3c89e1160d30eab4c3dfb257627dc92f1a00dc83a2e34a52826fec49f0a",
+    "frontend-modern/src/stores/updates.ts": "9f285a67198f095f69197b434874fcf70cddcec2c3ba0131e7897349a8d33ef8"
   },
   "routes": [
+    "/settings/system-updates",
     "/proxmox"
   ],
   "viewports": [
@@ -27,17 +30,24 @@
     }
   ],
   "states": [
-    "6.4.1 reproduction shows Offline and unavailable CPU despite live host report",
-    "Repaired backend output shows current agent and 17 percent CPU",
-    "Explicit offline control remains offline with unavailable live metrics",
-    "Expanded node Overview displays current agent identity"
+    "Diagnostic source version, Source and Development badges, no published release channel or agent update target",
+    "Cached same-version release offer discarded, source status and manual container image guidance",
+    "Disabled manual check, automatic updates and channel selection",
+    "Stable and preview release controls and install guidance remain available",
+    "Proxmox live host continuity shows current identity and 17 percent CPU with an older agent version, without an unpublished upgrade link"
   ],
   "interactions": [
-    "Two reloads preserve current identity, metrics and node count",
-    "Hover node row and expand inline details",
-    "Hover and focus collapse button, Escape preserves inline disclosure, Enter collapses it",
-    "Inspect actual pixels for node status, CPU, identity and narrow layout"
+    "Reload source build and inspect status, version and absent release offers",
+    "Hover and attempt focus on disabled Check Now",
+    "Scroll to automatic update control and inspect actual pixels at both viewports",
+    "Focus and press Enter on stable and preview Check Now, observe one forced check and successful result",
+    "Expand Proxmox node details, inspect current identity, collapse with Enter, reload and verify live CPU",
+    "Inspect source, stable, preview and expanded Proxmox pixels at both viewports"
   ],
-  "command": "node .agent-coordination/issue-1913-upgrade/browser-check.cjs (workspace root)",
-  "notes": "Current local frontend with a synthetic canonical resource emitted by the exact Go reproduction, added to the existing local API inventory. Browser isolated from inventory websocket updates. Compared original 6.4.1 backend output with repaired source. No production mutations or reporter environment access. Initial full-inventory replacement fixture caused reactive-cache errors and was excluded from proof. Final fixture preserves the existing inventory and source-query contract. Screenshots and backend receipts retained in the local issue investigation directory."
+  "command": "node .agent-coordination/issue-1913-upgrade/source-build-browser.cjs (workspace root)",
+  "notes": "Current local Vite build using actual version-handler regression payloads adapted to Docker context and public community runtime. Preview control derives from the stable payload using the version classifier fixture. Source cache seeded with a same-version available release. Proxmox uses the real Go continuity fixture inserted into the existing API inventory and an old synthetic agent version. No reporter environment access or production mutations. Browser page-error assertions pass. Screenshots, interaction matrix and proof logs retained in the local issue investigation directory.",
+  "backend_content_sha256": {
+    "internal/updates/version.go": "d8e426cfcc36e130a9b0faea97087620813ad07690865fa51e96b171d7fb7f17",
+    "internal/api/agent_version_shared.go": "3d40fe90f3d20a4b2e8fbe330198d70f0f2217447e776e775d47d2f9cdef53e7"
+  }
 }

--- a/frontend-modern/src/components/Settings/UpdateInstallGuide.tsx
+++ b/frontend-modern/src/components/Settings/UpdateInstallGuide.tsx
@@ -151,7 +151,13 @@ export const UpdateInstallGuide: Component<UpdateInstallGuideProps> = (props) =>
 
   return (
     <>
-      <Show when={props.versionInfo?.isDocker && !props.updateInfo?.available}>
+      <Show
+        when={
+          props.versionInfo?.isDocker &&
+          !props.versionInfo?.isSourceBuild &&
+          !props.updateInfo?.available
+        }
+      >
         <div class="space-y-3 rounded-md border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900">
           <div class="flex items-center gap-2">
             <svg
@@ -193,7 +199,13 @@ export const UpdateInstallGuide: Component<UpdateInstallGuideProps> = (props) =>
       <Show when={props.versionInfo?.isSourceBuild}>
         <div class="rounded-md border border-blue-200 bg-blue-50 p-3 dark:border-blue-800 dark:bg-blue-900">
           <p class="text-xs text-blue-800 dark:text-blue-200">
-            <strong>Built from source:</strong> Pull the latest code from git and rebuild to update.
+            <strong>Built from source:</strong>{' '}
+            <Show
+              when={props.versionInfo?.isDocker}
+              fallback="Pull the latest code from git and rebuild to change versions."
+            >
+              Replace the container image manually to change versions.
+            </Show>
           </p>
         </div>
       </Show>
@@ -204,7 +216,7 @@ export const UpdateInstallGuide: Component<UpdateInstallGuideProps> = (props) =>
         </div>
       </Show>
 
-      <Show when={props.updateInfo?.available && guide()}>
+      <Show when={!props.versionInfo?.isSourceBuild && props.updateInfo?.available && guide()}>
         <div class="overflow-hidden rounded-md border border-green-200 bg-green-50 dark:border-green-700 dark:bg-green-900">
           <div class="border-b border-green-200 bg-green-100 px-5 py-4 dark:border-green-800 dark:bg-green-800">
             <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx
+++ b/frontend-modern/src/components/Settings/UpdatesSettingsPanel.tsx
@@ -192,7 +192,7 @@ export const UpdatesSettingsPanel: Component<UpdatesSettingsPanelProps> = (props
                       fallback={
                         <>
                           <p class="mt-1 text-lg font-bold text-base-content">
-                            {getUpdatePrimaryStatusLabel(false)}
+                            {getUpdatePrimaryStatusLabel(false, props.versionInfo()?.isSourceBuild)}
                           </p>
                           <Show when={!props.versionInfo()?.isSourceBuild}>
                             <p class="mt-0.5 text-xs text-muted">
@@ -225,7 +225,12 @@ export const UpdatesSettingsPanel: Component<UpdatesSettingsPanelProps> = (props
 
             {/* Check for updates button */}
             <div class="bg-surface border-t border-border px-4 py-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <p class="text-xs text-muted">{getUpdateCheckModeLabel(props.autoUpdateEnabled())}</p>
+              <p class="text-xs text-muted">
+                {getUpdateCheckModeLabel(
+                  props.autoUpdateEnabled(),
+                  props.versionInfo()?.isSourceBuild,
+                )}
+              </p>
               <button
                 type="button"
                 onClick={props.checkForUpdates}

--- a/frontend-modern/src/components/Settings/__tests__/UpdateInstallGuide.test.tsx
+++ b/frontend-modern/src/components/Settings/__tests__/UpdateInstallGuide.test.tsx
@@ -7,6 +7,45 @@ describe('UpdateInstallGuide', () => {
     cleanup();
   });
 
+  it.each([false, true])(
+    'keeps source Docker builds out of release installation guidance (cached update: %s)',
+    (available) => {
+      render(() => (
+        <UpdateInstallGuide
+          versionInfo={{
+            version: '6.4.1+test.1913.bd37ae18',
+            build: 'development',
+            runtime: 'go',
+            isDocker: true,
+            isSourceBuild: true,
+            isDevelopment: true,
+          }}
+          updateInfo={{
+            available,
+            currentVersion: '6.4.1+test.1913.bd37ae18',
+            latestVersion: '6.4.4',
+            releaseNotes: '',
+            downloadUrl: '',
+            isPrerelease: false,
+            isMajorUpgrade: false,
+          }}
+          updatePlan={null}
+          isInstalling={false}
+          dockerImageTag="latest"
+          systemdDownloadCommand=""
+          isProRuntime={false}
+          onInstallUpdate={vi.fn()}
+        />
+      ));
+      expect(
+        screen.getByText('Replace the container image manually to change versions.'),
+      ).toBeInTheDocument();
+      expect(screen.queryByText('Docker Installation')).not.toBeInTheDocument();
+      expect(document.querySelector('code')).toBeNull();
+      expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+    },
+  );
+
   it('shows upgrade readiness checks from the update plan', () => {
     render(() => (
       <UpdateInstallGuide

--- a/frontend-modern/src/stores/__tests__/updates.test.ts
+++ b/frontend-modern/src/stores/__tests__/updates.test.ts
@@ -62,6 +62,25 @@ describe('updateStore', () => {
     mockNotifyError.mockReset();
   });
 
+  it.each(['isSourceBuild', 'isDevelopment'])(
+    'discards release cache for %s with the same version',
+    async (flag) => {
+      mockGetVersion.mockResolvedValue({ ...baseVersionInfo, [flag]: true });
+      localStorage.setItem(
+        STORAGE_KEYS.UPDATES,
+        JSON.stringify({
+          lastCheck: Date.now(),
+          updateInfo: baseUpdateInfo,
+        }),
+      );
+      const updateStore = await loadUpdateStore();
+      await updateStore.checkForUpdates();
+      expect(updateStore.updateAvailable()).toBe(false);
+      expect(updateStore.updateInfo()).toBeNull();
+      expect(mockCheckForUpdates).not.toHaveBeenCalled();
+    },
+  );
+
   it('forces a server refresh and preserves an unknown date in cached results', async () => {
     mockGetVersion.mockResolvedValue(baseVersionInfo);
     const info = { ...baseUpdateInfo, releaseDate: undefined };

--- a/frontend-modern/src/stores/updates.ts
+++ b/frontend-modern/src/stores/updates.ts
@@ -329,8 +329,13 @@ const performUpdateCheck = async (force: boolean): Promise<void> => {
           UpdatesAPI.getVersion(),
         );
         confirmPendingApply(currentVersion.version, state);
-        if (state.updateInfo.currentVersion !== currentVersion.version) {
-          // Version changed, invalidate cache and check again
+        if (
+          state.updateInfo.currentVersion !== currentVersion.version ||
+          currentVersion.isDevelopment ||
+          currentVersion.isSourceBuild
+        ) {
+          // Build identity also controls eligibility, even when a source
+          // marker keeps the same version as a previously installed release.
           state.updateInfo = undefined;
           state.dismissedVersion = undefined;
           state.lastCheck = 0;

--- a/frontend-modern/src/utils/__tests__/updatesPresentation.test.ts
+++ b/frontend-modern/src/utils/__tests__/updatesPresentation.test.ts
@@ -46,8 +46,11 @@ describe('updatesPresentation', () => {
     expect(getUpdateAvailabilityHeading(false)).toBe('Status');
     expect(getUpdatePrimaryStatusLabel(true)).toBe('Update Ready');
     expect(getUpdatePrimaryStatusLabel(false)).toBe('Up to date');
+    expect(getUpdatePrimaryStatusLabel(false, true)).toBe('Source build');
+    expect(getUpdatePrimaryStatusLabel(true, true)).toBe('Source build');
     expect(getUpdateCheckModeLabel(true)).toBe('Auto-check enabled');
     expect(getUpdateCheckModeLabel(false)).toBe('Manual checks only');
+    expect(getUpdateCheckModeLabel(true, true)).toBe('Release updates disabled');
     expect(getUpdateCheckActionLabel(true)).toBe('Checking...');
     expect(getUpdateCheckActionLabel(false)).toBe('Check Now');
   });

--- a/frontend-modern/src/utils/updatesPresentation.ts
+++ b/frontend-modern/src/utils/updatesPresentation.ts
@@ -66,11 +66,13 @@ export function getUpdateAvailabilityHeading(available: boolean): string {
   return available ? 'Available' : 'Status';
 }
 
-export function getUpdatePrimaryStatusLabel(available: boolean): string {
+export function getUpdatePrimaryStatusLabel(available: boolean, sourceBuild = false): string {
+  if (sourceBuild) return 'Source build';
   return available ? 'Update Ready' : 'Up to date';
 }
 
-export function getUpdateCheckModeLabel(enabled: boolean): string {
+export function getUpdateCheckModeLabel(enabled: boolean, sourceBuild = false): string {
+  if (sourceBuild) return 'Release updates disabled';
   return enabled ? 'Auto-check enabled' : 'Manual checks only';
 }
 

--- a/internal/api/agent_version_shared.go
+++ b/internal/api/agent_version_shared.go
@@ -8,7 +8,7 @@ import "github.com/rcourtman/pulse-go-rewrite/internal/updates"
 // when the server reports "dev" to avoid agent update loops.
 func currentAgentTargetVersion() string {
 	versionInfo, err := updates.GetCurrentVersion()
-	if err != nil || versionInfo.IsDevelopment {
+	if err != nil || versionInfo.IsDevelopment || versionInfo.IsSourceBuild {
 		return ""
 	}
 	return versionInfo.Version

--- a/internal/api/contract_test.go
+++ b/internal/api/contract_test.go
@@ -72,6 +72,50 @@ import (
 	tmock "github.com/stretchr/testify/mock"
 )
 
+func TestHandleVersionBuildIdentityContract(t *testing.T) {
+	oldBuildVersion := updates.BuildVersion
+	t.Cleanup(func() { updates.BuildVersion = oldBuildVersion })
+	for _, tc := range []struct {
+		name, version  string
+		marker, source bool
+	}{
+		{name: "release", version: "6.4.1"},
+		{name: "diagnostic", version: "6.4.1+test.1913.bd37ae18", source: true},
+		{name: "source marker", version: "6.4.1", marker: true, source: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			updates.BuildVersion = tc.version
+			if tc.marker {
+				if err := os.WriteFile("BUILD_FROM_SOURCE", []byte("1"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			router := &Router{updateManager: updates.NewManager(&config.Config{})}
+			rec := httptest.NewRecorder()
+			router.handleVersion(rec, httptest.NewRequest(http.MethodGet, "/api/version", nil))
+			if rec.Code != http.StatusOK {
+				t.Fatalf("version status = %d", rec.Code)
+			}
+			var payload VersionResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.Version != tc.version || payload.IsSourceBuild != tc.source {
+				t.Fatalf("unexpected build identity: %+v", payload)
+			}
+			if tc.source {
+				if payload.AgentUpdateTargetVersion != "" || payload.Channel != "" {
+					t.Fatalf("source build advertises a release target: %+v", payload)
+				}
+			} else if payload.AgentUpdateTargetVersion != tc.version || payload.Channel != "stable" {
+				t.Fatalf("release target was lost: %+v", payload)
+			}
+			t.Logf("version payload: %s", rec.Body.String())
+		})
+	}
+}
+
 func TestContractProxmoxInstallScopesRequireExplicitCommandChoice(t *testing.T) {
 	monitoringScopes := proxmoxAgentInstallScopes(false)
 	monitoringRecord := &config.APITokenRecord{Scopes: monitoringScopes}

--- a/internal/updates/manager_check_updates_test.go
+++ b/internal/updates/manager_check_updates_test.go
@@ -79,6 +79,20 @@ func TestCheckForUpdatesWithChannel_SourceBuild(t *testing.T) {
 	}
 }
 
+func TestCheckForUpdatesWithChannel_DiagnosticBuild(t *testing.T) {
+	oldBuildVersion := BuildVersion
+	BuildVersion = "6.4.1+test.1913.bd37ae18"
+	t.Cleanup(func() { BuildVersion = oldBuildVersion })
+	manager := NewManager(&config.Config{UpdateChannel: "stable"})
+	info, err := manager.CheckForUpdatesWithChannel(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Available || info.CurrentVersion != BuildVersion || info.LatestVersion != BuildVersion {
+		t.Fatalf("diagnostic build must not enter release update flow: %+v", info)
+	}
+}
+
 func TestCheckForUpdatesWithChannel_AvailableUsesCache(t *testing.T) {
 	var hits int32
 	releaseTime := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)

--- a/internal/updates/manager_check_updates_test.go
+++ b/internal/updates/manager_check_updates_test.go
@@ -31,6 +31,7 @@ func newReleaseServer(t *testing.T, releases []ReleaseInfo, hitCount *int32) *ht
 }
 
 func TestCheckForUpdatesWithChannel_UsesConfiguredRepoPath(t *testing.T) {
+	withBuildVersion(t, "6.4.0")
 	var hits int32
 	releases := []ReleaseInfo{
 		{
@@ -57,6 +58,7 @@ func TestCheckForUpdatesWithChannel_UsesConfiguredRepoPath(t *testing.T) {
 }
 
 func TestCheckForUpdatesWithChannel_SourceBuild(t *testing.T) {
+	withBuildVersion(t, "6.4.0")
 	markerPath := "BUILD_FROM_SOURCE"
 	if err := os.WriteFile(markerPath, []byte("1"), 0644); err != nil {
 		t.Fatalf("write %s: %v", markerPath, err)
@@ -94,6 +96,7 @@ func TestCheckForUpdatesWithChannel_DiagnosticBuild(t *testing.T) {
 }
 
 func TestCheckForUpdatesWithChannel_AvailableUsesCache(t *testing.T) {
+	withBuildVersion(t, "6.4.0")
 	var hits int32
 	releaseTime := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
 	releases := []ReleaseInfo{
@@ -146,6 +149,7 @@ func TestCheckForUpdatesWithChannel_AvailableUsesCache(t *testing.T) {
 }
 
 func TestCheckForUpdatesWithChannel_NoReleases(t *testing.T) {
+	withBuildVersion(t, "6.4.0")
 	var hits int32
 	releases := []ReleaseInfo{
 		{
@@ -176,6 +180,7 @@ func TestCheckForUpdatesWithChannel_NoReleases(t *testing.T) {
 }
 
 func TestCheckForUpdates_Wrapper(t *testing.T) {
+	withBuildVersion(t, "6.4.0")
 	var hits int32
 	releases := []ReleaseInfo{
 		{
@@ -213,6 +218,7 @@ func TestCheckForUpdates_Wrapper(t *testing.T) {
 }
 
 func TestForcedUpdateCheckRefreshesSavedChannelCache(t *testing.T) {
+	withBuildVersion(t, "6.4.0")
 	var hits int32
 	server := newReleaseServer(t, []ReleaseInfo{{TagName: "v99.0.0", Assets: []ReleaseAsset{{Name: "pulse-v99.0.0-linux-amd64.tar.gz", BrowserDownloadURL: "https://example.com/new.tar.gz"}}}}, &hits)
 	defer server.Close()

--- a/internal/updates/version.go
+++ b/internal/updates/version.go
@@ -232,14 +232,27 @@ func GetCurrentVersion() (*VersionInfo, error) {
 
 	buildInfo := func(raw string, build string, isDev bool) *VersionInfo {
 		normalized := normalizeVersionString(raw)
+		identity := DescribeUsageDataVersion(normalized)
+		isDev = isDev || identity.IsDevelopment
+		sourceBuild := isSourceBuildEnvironment() || isDev
+		channel := detectChannelFromVersion(normalized)
+		if sourceBuild {
+			// Source builds have no published release channel. Keep their
+			// exact version while excluding them from release update flows.
+			channel = ""
+			build = "source"
+			if isDev {
+				build = "development"
+			}
+		}
 		info := &VersionInfo{
 			Version:        normalized,
 			Build:          build,
 			Runtime:        "go",
-			Channel:        detectChannelFromVersion(normalized),
+			Channel:        channel,
 			IsDevelopment:  isDev,
 			IsDocker:       isDockerEnvironment(),
-			IsSourceBuild:  isSourceBuildEnvironment(),
+			IsSourceBuild:  sourceBuild,
 			DeploymentType: GetDeploymentType(),
 		}
 

--- a/internal/updates/version_additional_test.go
+++ b/internal/updates/version_additional_test.go
@@ -49,6 +49,42 @@ func TestGetCurrentVersion_UsesBuildVersion(t *testing.T) {
 	}
 }
 
+func TestGetCurrentVersion_SourceBuildIdentity(t *testing.T) {
+	oldBuildVersion := BuildVersion
+	t.Cleanup(func() { BuildVersion = oldBuildVersion })
+	t.Setenv("PATH", "")
+	for _, tc := range []struct {
+		name, version, build, channel string
+		marker, source, development   bool
+	}{
+		{name: "stable", version: "6.4.1", build: "release", channel: "stable"},
+		{name: "preview", version: "6.4.4-beta.1", build: "release", channel: "rc"},
+		{name: "reporter", version: "6.4.1+test.1913.bd37ae18", build: "development", source: true, development: true},
+		{name: "git metadata", version: "6.4.1+git.2.gabcdef", build: "development", source: true, development: true},
+		{name: "dev base", version: "6.4.1-dev", build: "development", source: true, development: true},
+		{name: "sentinel", version: "0.0.0-qual-build", build: "development", source: true, development: true},
+		{name: "marker", version: "6.4.1", build: "source", marker: true, source: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			BuildVersion = tc.version
+			if tc.marker {
+				if err := os.WriteFile("BUILD_FROM_SOURCE", []byte("1"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			info, err := GetCurrentVersion()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Version != tc.version || info.Build != tc.build || info.Channel != tc.channel ||
+				info.IsSourceBuild != tc.source || info.IsDevelopment != tc.development {
+				t.Fatalf("unexpected build identity: %+v", info)
+			}
+		})
+	}
+}
+
 func TestGetCurrentVersion_UsesVersionFile(t *testing.T) {
 	setMockRuntime(t, false)
 
@@ -140,8 +176,8 @@ func TestGetCurrentVersion_UsesVersionFileAsDevelopmentBase(t *testing.T) {
 	if !info.IsDevelopment {
 		t.Fatalf("IsDevelopment = false, want true")
 	}
-	if info.Channel != "stable" {
-		t.Fatalf("Channel = %q, want stable", info.Channel)
+	if !info.IsSourceBuild || info.Channel != "" {
+		t.Fatalf("development build must be source-only: %+v", info)
 	}
 }
 


### PR DESCRIPTION
Diagnostic Docker builds were reported as stable releases and offered an agent update version that was never published. Classify source versions through the existing canonical version identity, omit release channels and agent targets, and discard stale cached release offers. Update settings now show source-build status and manual image replacement guidance.

Verified targeted Go regression and race tests, 105 frontend tests, and browser checks at 1440×900 and 390×900 on `/settings/system-updates` and `/proxmox`. Stable and preview update checks still work. The host continuity regression for #1913 also passes.

Refs #1913
