### PR TITLE
diagnostic: run hosted lifecycle fixture on DeepSeek V4.1 Flash

### DIFF
--- a/internal/ai/chat/hosted_lifecycle_diagnostic_test.go
+++ b/internal/ai/chat/hosted_lifecycle_diagnostic_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const diagnosticModel = "google/gemini-2.5-flash"
+const diagnosticModel = "deepseek/deepseek-v4.1-flash"
 const diagnosticPrompt = "Find the five VMs named win-01 through win-05 and prepare their reboot plans. Do not execute any action."
 
 // A hard logical-call boundary also counts final-response/recovery calls, which


### PR DESCRIPTION
Replaces google/gemini-2.5-flash with deepseek/deepseek-v4.1-flash (released 2026-09-10) as the diagnosticModel for the hosted lifecycle diagnostic and its synthetic fixture/wire tests. Synthetic tests pass locally.