### PR TITLE
fix(alerts): prevent stale observations from manufacturing recovery

### DIFF
--- a/internal/ai/alert_adapter.go
+++ b/internal/ai/alert_adapter.go
@@ -2,6 +2,7 @@ package ai
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/rcourtman/pulse-go-rewrite/internal/alerts"
@@ -206,9 +207,10 @@ func normalizeAlertResourceType(raw string) string {
 	}
 }
 
-// ResolveAlert clears an active alert. Returns true if the alert was found and cleared.
+// ResolveAlert clears a resource alert. System health recovery belongs to its
+// owning evaluator, including when resolution is requested outside Patrol.
 func (a *AlertManagerAdapter) ResolveAlert(alertID string) bool {
-	if a.manager == nil {
+	if a.manager == nil || strings.HasPrefix(alertID, alerts.SystemAlertIDPrefix) {
 		return false
 	}
 	return a.manager.ClearAlert(alertID)

--- a/internal/ai/patrol_run.go
+++ b/internal/ai/patrol_run.go
@@ -2429,6 +2429,12 @@ func (p *PatrolService) reviewAndResolveAlertsState(ctx context.Context, state p
 	var alertsToReview []AlertInfo
 	stillFiring := 0
 	for _, alert := range activeAlerts {
+		// Pulse health has no inventory resource. Only its owning health
+		// evaluator can establish recovery; a missing "Pulse VM" cannot.
+		if strings.HasPrefix(alert.ID, alerts.SystemAlertIDPrefix) {
+			continue
+		}
+
 		if time.Since(alert.StartTime) < minAge {
 			continue
 		}

--- a/internal/ai/system_alert_recovery_regression_test.go
+++ b/internal/ai/system_alert_recovery_regression_test.go
@@ -1,0 +1,39 @@
+package ai
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rcourtman/pulse-go-rewrite/internal/alerts"
+	"github.com/rcourtman/pulse-go-rewrite/internal/config"
+	"github.com/rcourtman/pulse-go-rewrite/internal/models"
+)
+
+func TestPatrolDoesNotReviewSystemAlertsAsMissingResources(t *testing.T) {
+	ps := NewPatrolService(nil, nil)
+	resolver := &stubAlertResolver{alerts: []AlertInfo{{
+		ID:   alerts.SystemAlertID(alerts.NotificationDeliveryAlertType),
+		Type: alerts.NotificationDeliveryAlertType, ResourceName: "Pulse",
+		StartTime: time.Now().Add(-25 * time.Hour),
+	}}}
+	provider := &mockPatrolProvider{response: "ALERT 1: RESOLVE: Pulse VM is no longer found"}
+	ps.alertResolver = resolver
+	ps.aiService = &Service{provider: provider, cfg: &config.AIConfig{Enabled: true, PatrolModel: "mock:model"}}
+	resolved := ps.reviewAndResolveAlertsState(context.Background(), patrolRuntimeStateForTest(ps, models.StateSnapshot{}), true, "")
+	if resolved != 0 || len(resolver.clears) != 0 || provider.calls != 0 {
+		t.Fatalf("system health reviewed as inventory: resolved=%d clears=%v model calls=%d", resolved, resolver.clears, provider.calls)
+	}
+}
+
+func TestAlertAdapterRejectsSystemAlertResolution(t *testing.T) {
+	a := NewAlertManagerAdapter(&stubAlertManager{})
+	for _, kind := range []string{alerts.NotificationDeliveryAlertType, alerts.DeadManDeliveryAlertType, alerts.DeadManMonitoringStalledAlertType} {
+		if a.ResolveAlert(alerts.SystemAlertID(kind)) {
+			t.Errorf("AI adapter allowed resolution of system health %s", kind)
+		}
+	}
+	if !a.ResolveAlert("ordinary-resource-alert") {
+		t.Fatal("ordinary resource resolution should remain available")
+	}
+}

--- a/internal/alerts/stale_recovery_regression_test.go
+++ b/internal/alerts/stale_recovery_regression_test.go
@@ -1,0 +1,40 @@
+package alerts
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCleanupStaleMapsDoesNotManufactureRecovery(t *testing.T) {
+	m := newTestManager(t)
+	old := time.Now().Add(-25 * time.Hour)
+	ids := []string{"guest-powered-state", "node-connectivity", "pbs-connectivity", "agent-connectivity", SystemAlertID(NotificationDeliveryAlertType)}
+	m.mu.Lock()
+	for _, id := range ids {
+		m.setActiveAlertNoLock(id, &Alert{ID: id, ResourceID: id, StartTime: old, LastSeen: old, Level: AlertLevelWarning})
+	}
+	m.mu.Unlock()
+
+	// An absent observation is not recovery, even across repeated cleanup runs.
+	for sweep := 0; sweep < 2; sweep++ {
+		m.cleanupStaleMaps()
+		if got := len(m.GetActiveAlerts()); got != len(ids) {
+			t.Fatalf("cleanup %d retained %d alerts, want %d without recovery evidence", sweep, got, len(ids))
+		}
+		if got := m.GetRecentlyResolved(); len(got) != 0 {
+			t.Fatalf("cleanup manufactured recovery events: %+v", got)
+		}
+	}
+
+	// Explicit resolution remains available and records the actual transition.
+	if !m.ClearAlert(ids[0]) {
+		t.Fatal("explicit resolution failed")
+	}
+	m.cleanupStaleMaps()
+	if got := len(m.GetActiveAlerts()); got != len(ids)-1 {
+		t.Fatalf("active alerts after explicit resolution = %d", got)
+	}
+	if got := m.GetRecentlyResolved(); len(got) != 1 || got[0].Alert.ID != ids[0] {
+		t.Fatalf("expected only the explicitly resolved occurrence, got %+v", got)
+	}
+}

--- a/internal/alerts/tracking_cleanup.go
+++ b/internal/alerts/tracking_cleanup.go
@@ -139,36 +139,11 @@ func (m *Manager) cleanupStaleMaps() {
 		}
 	}
 
-	staleAlerts := make([]string, 0)
-	for storageKey, alert := range m.activeAlerts {
-		alertID := effectiveAlertID(alert, storageKey)
-		if alert != nil && now.Sub(alert.LastSeen) > staleThreshold {
-			staleAlerts = append(staleAlerts, alertID)
-		}
-	}
-	staleResolved := 0
-	for _, alertID := range staleAlerts {
-		alert, exists := m.getActiveAlertNoLock(alertID)
-		if !exists || alert == nil {
-			continue
-		}
-		log.Info().
-			Str("alertID", alertID).
-			Str("resourceName", alert.ResourceName).
-			Time("lastSeen", alert.LastSeen).
-			Dur("staleFor", now.Sub(alert.LastSeen)).
-			Msg("Auto-resolving stale alert - resource no longer being monitored")
-		m.clearAlertNoLock(alertID)
-		cleaned++
-		staleResolved++
-	}
-
-	if staleResolved > 0 {
-		m.saveActiveAlertsAsync("stale cleanup")
-		log.Info().
-			Int("count", staleResolved).
-			Msg("Auto-resolved stale alerts")
-	}
+	// LastSeen describes the last observation, not proof that the condition
+	// recovered or the resource was removed. Resolving active alerts here
+	// manufactured recovery notifications 24 hours after monitoring stopped.
+	// Leave their lifecycle to observed recovery, explicit resource/operator
+	// reconciliation, and the configured retention policy in Cleanup.
 
 	if cleaned > 0 {
 		log.Debug().


### PR DESCRIPTION
Active alerts whose LastSeen timestamp exceeds 24 hours are currently cleared by stale-map cleanup, generating recovery notifications without an observed recovery. A support report exposed a burst of these transitions. AI Patrol can also misclassify Pulse system health as a missing inventory resource and clear its alert.

This maintainer-requested change removes timestamp-only active-alert resolution from tracking-map cleanup, excludes system alerts from Patrol recovery review, and rejects system-alert resolution at the AI adapter boundary. Recovery remains owned by health evaluators, observed resource recovery, explicit reconciliation/operator actions, and existing retention policy.

Adds three synthetic regression tests covering repeated stale cleanup without recovery events, explicit resource resolution, Patrol skipping system alerts without calling the model, and adapter rejection of system health resolution.

Validation:
- All three new tests fail against the original main baseline and pass with this change.
- Focused alert cleanup, Patrol recovery, and adapter tests pass on Windows with Go 1.26.8.
- Formatting and git diff --check pass; remote branch content verified against the tested patch (one additional blank line only).
- Full internal/alerts and internal/ai suites are not green on Windows: 6 alert failures and 83 AI top-level failures. All 6 alert failures reproduce on the baseline; sampled AI failures also reproduce, including SQLite file locks, permission expectations, and timing. Not every AI failure has been baseline-qualified.

Draft pending Linux CI/race checks and installed-build validation. The separate earlier delayed warning email and the reason the original alert records stopped receiving observations remain unproven; this PR addresses the demonstrated false-recovery paths. No customer logs or identifying data are included.